### PR TITLE
Added Route Guard to COVID-Net UI for Dashboard, Create Analysis, and View Image pages

### DIFF
--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -1,19 +1,16 @@
-// This is used to determine if a user is authenticated and
-// if they are allowed to visit the page they navigated to.
-
-// If they are: they proceed to the page
-// If not: they are redirected to the login page.
 import React, { useContext } from 'react'
 import { Redirect, Route } from 'react-router-dom'
 import { AppContext } from './context/context'
 
-const PrivateRoute = (component: any, path: string) => {
+interface PrivateRouteProps {
+  component: React.FC<any>;
+  path: string;
+}
 
-  // Add your own authentication on the below line.
+const PrivateRoute: React.FC<PrivateRouteProps> = (props: PrivateRouteProps) => {
   const isLoggedIn = useContext(AppContext).state.user.loggedIn;
 
-  return  isLoggedIn ? (<Route  path={path}  exact={true} component={component} />) : 
-  (<Redirect  to="/login"  />);
+  return (isLoggedIn ? (<Route {...props} exact={true} />) : (<Redirect  to="/login"  />));
 }
 
 export default PrivateRoute

--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -14,4 +14,4 @@ const PrivateRoute: React.FC<PrivateRouteProps> = (props: PrivateRouteProps) => 
   return (isLoggedIn ? (<Route {...props} />) : (<Redirect to="/login" />));
 }
 
-export default PrivateRoute
+export default PrivateRoute;

--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -9,7 +9,7 @@ interface PrivateRouteProps {
 }
 
 const PrivateRoute: React.FC<PrivateRouteProps> = (props: PrivateRouteProps) => {
-  const isLoggedIn = useContext(AppContext).state.user.loggedIn;
+  const { state: { user: isLoggedIn } } = useContext(AppContext);
 
   return (isLoggedIn ? (<Route {...props} />) : (<Redirect to="/login" />));
 }

--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react'
-import { Redirect, Route } from 'react-router-dom'
-import { AppContext } from './context/context'
+import React, { useContext } from "react"
+import { Redirect, Route } from "react-router-dom"
+import { AppContext } from "./context/context"
 
 interface PrivateRouteProps {
   component: React.FC<any>;
@@ -10,7 +10,7 @@ interface PrivateRouteProps {
 const PrivateRoute: React.FC<PrivateRouteProps> = (props: PrivateRouteProps) => {
   const isLoggedIn = useContext(AppContext).state.user.loggedIn;
 
-  return (isLoggedIn ? (<Route {...props} exact={true} />) : (<Redirect  to="/login"  />));
+  return (isLoggedIn ? (<Route {...props} exact={true} />) : (<Redirect to="/login" />));
 }
 
 export default PrivateRoute

--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -1,16 +1,17 @@
-import React, { useContext } from "react"
-import { Redirect, Route } from "react-router-dom"
-import { AppContext } from "./context/context"
+import React, { useContext } from "react";
+import { Redirect, Route } from "react-router-dom";
+import { AppContext } from "./context/context";
 
 interface PrivateRouteProps {
   component: React.FC<any>;
   path: string;
+  exact: boolean;
 }
 
 const PrivateRoute: React.FC<PrivateRouteProps> = (props: PrivateRouteProps) => {
   const isLoggedIn = useContext(AppContext).state.user.loggedIn;
 
-  return (isLoggedIn ? (<Route {...props} exact={true} />) : (<Redirect to="/login" />));
+  return (isLoggedIn ? (<Route {...props} />) : (<Redirect to="/login" />));
 }
 
 export default PrivateRoute

--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -1,0 +1,19 @@
+// This is used to determine if a user is authenticated and
+// if they are allowed to visit the page they navigated to.
+
+// If they are: they proceed to the page
+// If not: they are redirected to the login page.
+import React, { useContext } from 'react'
+import { Redirect, Route } from 'react-router-dom'
+import { AppContext } from './context/context'
+
+const PrivateRoute = (component: any, path: string) => {
+
+  // Add your own authentication on the below line.
+  const isLoggedIn = useContext(AppContext).state.user.loggedIn;
+
+  return  isLoggedIn ? (<Route  path={path}  exact={true} component={component} />) : 
+  (<Redirect  to="/login"  />);
+}
+
+export default PrivateRoute

--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -9,7 +9,7 @@ interface PrivateRouteProps {
 }
 
 const PrivateRoute: React.FC<PrivateRouteProps> = (props: PrivateRouteProps) => {
-  const { state: { user: isLoggedIn } } = useContext(AppContext);
+  const { state: { user: { loggedIn: isLoggedIn } } } = useContext(AppContext);
 
   return (isLoggedIn ? (<Route {...props} />) : (<Redirect to="/login" />));
 }

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -8,9 +8,7 @@ import { AnalysisTypes, CreateAnalysisTypes, NotificationActionTypes, StagingDcm
 import { AppContext } from "../../context/context";
 import CreateAnalysisService from "../../services/CreateAnalysisService";
 
-type AllProps = RouteComponentProps;
-
-const DashboardPage: React.FC<AllProps> = () => {
+const DashboardPage = () => {
   const { state: { stagingDcmImages, models }, dispatch } = useContext(AppContext);
 
   useEffect(() => {

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -8,7 +8,9 @@ import { AnalysisTypes, CreateAnalysisTypes, NotificationActionTypes, StagingDcm
 import { AppContext } from "../../context/context";
 import CreateAnalysisService from "../../services/CreateAnalysisService";
 
-const DashboardPage = () => {
+type AllProps = RouteComponentProps;
+
+const DashboardPage: React.FC<AllProps> = () => {
   const { state: { stagingDcmImages, models }, dispatch } = useContext(AppContext);
 
   useEffect(() => {

--- a/src/pages/LogIn/components/LoginForm.tsx
+++ b/src/pages/LogIn/components/LoginForm.tsx
@@ -8,9 +8,9 @@ import { handleLogin } from "../../../services/login";
 const LoginFormComponent = () => {
   const history = useHistory();
   const [showHelperText] = useState(false);
-  const [usernameValue, setUsernameValue] = useState('chris');
+  const [usernameValue, setUsernameValue] = useState('');
   const [isValidUsername] = useState(true);
-  const [passwordValue, setPasswordValue] = useState('chris1234');
+  const [passwordValue, setPasswordValue] = useState('');
   const [RememberMeClick, setRememberMeClick] = useState(true);
 
   const { dispatch } = React.useContext(AppContext);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,21 +13,15 @@ import ViewImagePage from "./pages/viewImage/ViewImagePage";
 import PrivateRoute from "./PrivateRoute";
 
 const Routes: React.FunctionComponent = () => (
-    <React.Fragment>
-      <Switch>
-        {/* <Route exact path="/" component={Dashboard} /> */}
-        <Route exact path="/login" component={LogInPage} />
-        <PrivateRoute component={Dashboard} path="/"/>
-        {/* <Route exact path="/createAnalysis" component={CreateAnalysisPage} />
-        <Route exact path="/viewImage" component={ViewImagePage} /> */}
-        <PrivateRoute component={CreateAnalysisPage} path="/createAnalysis"/>
-        <PrivateRoute component={ViewImagePage} path="/viewImage"/>
-        <Route component={NotFound} />
-      </Switch>
-    </React.Fragment>
+  <React.Fragment>
+    <Switch>
+      <Route exact path="/login" component={LogInPage} />
+      <PrivateRoute component={Dashboard} path="/" />
+      <PrivateRoute component={CreateAnalysisPage} path="/createAnalysis" />
+      <PrivateRoute component={ViewImagePage} path="/viewImage" />
+      <Route component={NotFound} />
+    </Switch>
+  </React.Fragment>
 );
-
-
-
 
 export default Routes;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -10,14 +10,18 @@ import { Dashboard } from "./pages/Dashboard/Dashboard";
 import LogInPage from "./pages/LogIn/Login";
 import { NotFound } from "./pages/NotFound/NotFound";
 import ViewImagePage from "./pages/viewImage/ViewImagePage";
+import PrivateRoute from "./PrivateRoute";
 
 const Routes: React.FunctionComponent = () => (
     <React.Fragment>
       <Switch>
-        <Route exact path="/" component={Dashboard} />
+        {/* <Route exact path="/" component={Dashboard} /> */}
         <Route exact path="/login" component={LogInPage} />
-        <Route exact path="/createAnalysis" component={CreateAnalysisPage} />
-        <Route exact path="/viewImage" component={ViewImagePage} />
+        <PrivateRoute component={Dashboard} path="/"/>
+        {/* <Route exact path="/createAnalysis" component={CreateAnalysisPage} />
+        <Route exact path="/viewImage" component={ViewImagePage} /> */}
+        <PrivateRoute component={CreateAnalysisPage} path="/createAnalysis"/>
+        <PrivateRoute component={ViewImagePage} path="/viewImage"/>
         <Route component={NotFound} />
       </Switch>
     </React.Fragment>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -16,9 +16,9 @@ const Routes: React.FunctionComponent = () => (
   <React.Fragment>
     <Switch>
       <Route exact path="/login" component={LogInPage} />
-      <PrivateRoute component={Dashboard} path="/" />
-      <PrivateRoute component={CreateAnalysisPage} path="/createAnalysis" />
-      <PrivateRoute component={ViewImagePage} path="/viewImage" />
+      <PrivateRoute exact component={Dashboard} path="/" />
+      <PrivateRoute exact component={CreateAnalysisPage} path="/createAnalysis" />
+      <PrivateRoute exact component={ViewImagePage} path="/viewImage" />
       <Route component={NotFound} />
     </Switch>
   </React.Fragment>


### PR DESCRIPTION
Improve security and user experience by directly re-routing users back to the log-in page, if detected to be not logged in previously. Avoids bugs that arise due to user accessing the Dashboard (or other private pages) without proper security and removes error that arose from ChRIS when this occurred

Route guard checks for user being logged in and directs user accordingly, making sensitive pages private