### PR TITLE
[CNXC-193] Multi-user functionality

### DIFF
--- a/src/RouterWrapper.tsx
+++ b/src/RouterWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import ChrisAPIClient from "./api/chrisapiclient";
 import { AppContext } from "./context/context";
 import { Types } from "./context/actions/types";
@@ -7,22 +7,25 @@ import Client, { User } from "@fnndsc/chrisapi";
 
 const RouterWrapper: React.FC = ({ children }) => {
   const { dispatch } = React.useContext(AppContext);
+  const [renderChildren, setRenderChildren] = useState(false);
 
   useEffect(() => {
     const token = window.sessionStorage.getItem("AUTH_TOKEN");
-    if (!!token) {
-      const client: Client = ChrisAPIClient.getClient();
-      client.getUser().then((res: User) => {
+    (async () => {
+      if (!!token) {
+        const client: Client = ChrisAPIClient.getClient();
+        const res: User = await client.getUser();
         const user: IUserState = res?.data;
         dispatch({
-            type: Types.Login_update,
-            payload: user
-        });
-      })
-    }
+          type: Types.Login_update,
+          payload: user
+        });          
+      }
+      setRenderChildren(true);
+    })(); 
   }, [dispatch]);
 
-  return (<>{children}</>);
+  return (renderChildren ? <>{children}</> : null);
 }
 
 export default RouterWrapper;

--- a/src/RouterWrapper.tsx
+++ b/src/RouterWrapper.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from "react";
+import ChrisAPIClient from "./api/chrisapiclient";
+import { AppContext } from "./context/context";
+import { Types } from "./context/actions/types";
+import { IUserState, UserResponse } from "./context/reducers/userReducer";
+
+const RouterWrapper: React.FC = ({ children }) => {
+    const { dispatch } = React.useContext(AppContext);
+
+    useEffect(() => {
+        const token = window.sessionStorage.getItem("AUTH_TOKEN");
+        if (!!token) {
+            const client: any = ChrisAPIClient.getClient();
+            client.getUser().then((res: UserResponse) => {
+            const user: IUserState = res?.data;
+            dispatch({
+                type: Types.Login_update,
+                payload: user
+            });
+            })
+        }
+    }, [dispatch]);
+
+    return (<>{children}</>);
+}
+
+export default RouterWrapper;

--- a/src/RouterWrapper.tsx
+++ b/src/RouterWrapper.tsx
@@ -2,26 +2,27 @@ import React, { useEffect } from "react";
 import ChrisAPIClient from "./api/chrisapiclient";
 import { AppContext } from "./context/context";
 import { Types } from "./context/actions/types";
-import { IUserState, UserResponse } from "./context/reducers/userReducer";
+import { IUserState } from "./context/reducers/userReducer";
+import Client, { User } from "@fnndsc/chrisapi";
 
 const RouterWrapper: React.FC = ({ children }) => {
-    const { dispatch } = React.useContext(AppContext);
+  const { dispatch } = React.useContext(AppContext);
 
-    useEffect(() => {
-        const token = window.sessionStorage.getItem("AUTH_TOKEN");
-        if (!!token) {
-            const client: any = ChrisAPIClient.getClient();
-            client.getUser().then((res: UserResponse) => {
-            const user: IUserState = res?.data;
-            dispatch({
-                type: Types.Login_update,
-                payload: user
-            });
-            })
-        }
-    }, [dispatch]);
+  useEffect(() => {
+    const token = window.sessionStorage.getItem("AUTH_TOKEN");
+    if (!!token) {
+      const client: Client = ChrisAPIClient.getClient();
+      client.getUser().then((res: User) => {
+        const user: IUserState = res?.data;
+        dispatch({
+            type: Types.Login_update,
+            payload: user
+        });
+      })
+    }
+  }, [dispatch]);
 
-    return (<>{children}</>);
+  return (<>{children}</>);
 }
 
 export default RouterWrapper;

--- a/src/RouterWrapper.tsx
+++ b/src/RouterWrapper.tsx
@@ -4,10 +4,17 @@ import { AppContext } from "./context/context";
 import { Types } from "./context/actions/types";
 import { IUserState } from "./context/reducers/userReducer";
 import Client, { User } from "@fnndsc/chrisapi";
+import { useLocation, useHistory } from 'react-router-dom'
 
+/**
+ * Allows user to bypass Login page if already authenticated by checking AUTH_TOKEN
+ * in session storage
+ */
 const RouterWrapper: React.FC = ({ children }) => {
   const { dispatch } = React.useContext(AppContext);
   const [renderChildren, setRenderChildren] = useState(false);
+  const location = useLocation();
+  const history = useHistory();
 
   useEffect(() => {
     const token = window.sessionStorage.getItem("AUTH_TOKEN");
@@ -19,7 +26,12 @@ const RouterWrapper: React.FC = ({ children }) => {
         dispatch({
           type: Types.Login_update,
           payload: user
-        });          
+        });
+        
+        // If on Login page and already authenticated, go to Dashboard
+        if (location.pathname === "/login") {
+          history.push('/');
+        }
       }
       setRenderChildren(true);
     })(); 

--- a/src/api/chrisapiclient.ts
+++ b/src/api/chrisapiclient.ts
@@ -17,21 +17,25 @@ const AUTH_TOKEN_KEY = 'AUTH_TOKEN';
 class ChrisAPIClient {
 
   private static client: Client;
-  private static tokenUnauthorized: boolean;
+  private static tokenIsUnauthorized: boolean;
 
   static getClient(): Client {
-    if (!this.client || this.tokenUnauthorized) {
+    if (!this.client || this.tokenIsUnauthorized) {
       const token: string = window.sessionStorage.getItem(AUTH_TOKEN_KEY) || '';
-      if (token === '') {
-        this.tokenUnauthorized = true;
+      if (token) {
+        this.tokenIsUnauthorized = true;
       } else {
-        this.tokenUnauthorized = false;
+        this.tokenIsUnauthorized = false;
       }
       this.client = new Client(process.env.REACT_APP_CHRIS_UI_URL, {
         token
       });
     }
     return this.client;
+  }
+
+  static setTokenIsUnauthorized(tokenIsUnauthorized: boolean) {
+    this.tokenIsUnauthorized = tokenIsUnauthorized;
   }
 
 }

--- a/src/api/chrisapiclient.ts
+++ b/src/api/chrisapiclient.ts
@@ -17,15 +17,15 @@ const AUTH_TOKEN_KEY = 'AUTH_TOKEN';
 class ChrisAPIClient {
 
   private static client: Client;
-  private static tokenIsUnauthorized: boolean;
+  private static isTokenAuthorized: boolean;
 
   static getClient(): Client {
-    if (!this.client || this.tokenIsUnauthorized) {
+    if (!this.client || !this.isTokenAuthorized) {
       const token: string = window.sessionStorage.getItem(AUTH_TOKEN_KEY) || '';
       if (token) {
-        this.tokenIsUnauthorized = true;
+        this.isTokenAuthorized = true;
       } else {
-        this.tokenIsUnauthorized = false;
+        this.isTokenAuthorized = false;
       }
       this.client = new Client(process.env.REACT_APP_CHRIS_UI_URL, {
         token
@@ -34,8 +34,8 @@ class ChrisAPIClient {
     return this.client;
   }
 
-  static setTokenIsUnauthorized(tokenIsUnauthorized: boolean) {
-    this.tokenIsUnauthorized = tokenIsUnauthorized;
+  static setIsTokenAuthorized(value: boolean) {
+    this.isTokenAuthorized = value;
   }
 
 }

--- a/src/containers/Layout/Header.tsx
+++ b/src/containers/Layout/Header.tsx
@@ -35,7 +35,7 @@ const Header: React.FC<HeaderProps> = ({ onNotificationBadgeClick }) => {
 
   const logout = () => {
     window.sessionStorage.removeItem("AUTH_TOKEN");
-    ChrisAPIClient.setTokenIsUnauthorized(true);
+    ChrisAPIClient.setIsTokenAuthorized(false);
     dispatch({
       type: Types.Logout_update,
       payload: null

--- a/src/containers/Layout/Header.tsx
+++ b/src/containers/Layout/Header.tsx
@@ -17,6 +17,7 @@ import { Types } from "../../context/actions/types";
 import { AppContext } from "../../context/context";
 import { NotificationItemVariant } from "../../context/reducers/notificationReducer";
 import PageNav from "./PageNav";
+import ChrisAPIClient from "../../api/chrisapiclient";
 
 interface HeaderProps {
   onNotificationBadgeClick: () => void;
@@ -26,6 +27,7 @@ const Header: React.FC<HeaderProps> = ({ onNotificationBadgeClick }) => {
   const history = useHistory()
   const { state, dispatch } = React.useContext(AppContext);
   const [isDropdownOpen, setIsDropdownOpen] = React.useState(false)
+  const username = state.user.username;
 
   const onDropdownSelect = () => {
     setIsDropdownOpen(!isDropdownOpen)
@@ -34,6 +36,7 @@ const Header: React.FC<HeaderProps> = ({ onNotificationBadgeClick }) => {
   const logout = () => {
     window.sessionStorage.removeItem("AUTH_TOKEN");
     window.sessionStorage.removeItem("USERNAME");
+    ChrisAPIClient.setTokenIsUnauthorized(true);
     dispatch({
       type: Types.Logout_update,
       payload: null
@@ -65,7 +68,7 @@ const Header: React.FC<HeaderProps> = ({ onNotificationBadgeClick }) => {
           <Dropdown
             isPlain
             position="right"
-            toggle={<DropdownToggle onToggle={(isOpen: boolean) => setIsDropdownOpen(isOpen)}>Dr. Chris Covid</DropdownToggle>}
+            toggle={<DropdownToggle onToggle={(isOpen: boolean) => setIsDropdownOpen(isOpen)}>{username}</DropdownToggle>}
             isOpen={isDropdownOpen}
             onSelect={onDropdownSelect}
             dropdownItems={userDropdownItems}

--- a/src/containers/Layout/Header.tsx
+++ b/src/containers/Layout/Header.tsx
@@ -35,7 +35,6 @@ const Header: React.FC<HeaderProps> = ({ onNotificationBadgeClick }) => {
 
   const logout = () => {
     window.sessionStorage.removeItem("AUTH_TOKEN");
-    window.sessionStorage.removeItem("USERNAME");
     ChrisAPIClient.setTokenIsUnauthorized(true);
     dispatch({
       type: Types.Logout_update,

--- a/src/containers/Layout/PageWrapper.tsx
+++ b/src/containers/Layout/PageWrapper.tsx
@@ -5,6 +5,8 @@ import { AppContext } from "../../context/context";
 import Header from "./Header";
 import "./layout.scss";
 import NotificationDrawerWrapper from "./NotificationDrawerWrapper";
+import ChrisAPIClient from "../../api/chrisapiclient";
+import { IUserState, UserResponse } from "../../context/reducers/userReducer";
 
 interface WrapperProps {
   children: React.ReactNode
@@ -16,14 +18,16 @@ const Wrapper = (props: WrapperProps) => {
   const [isDrawerExpanded, setIsDrawerOpen] = React.useState(false);
 
   React.useEffect(()=>{
-    const token = window.sessionStorage.getItem('AUTH_TOKEN')
+    const token = window.sessionStorage.getItem('AUTH_TOKEN');
     if (!!token) {
-      dispatch({
-        type: Types.Login_update,
-        payload: {
-          username: window.sessionStorage.getItem('USERNAME'),
-        }
-      });
+      const client: any = ChrisAPIClient.getClient();
+      client.getUser().then((res: UserResponse) => {
+        const user: IUserState = res?.data;
+        dispatch({
+          type: Types.Login_update,
+          payload: user,
+        });
+      })
     }
   },[dispatch])
 

--- a/src/containers/Layout/PageWrapper.tsx
+++ b/src/containers/Layout/PageWrapper.tsx
@@ -18,18 +18,18 @@ const Wrapper = (props: WrapperProps) => {
   const [isDrawerExpanded, setIsDrawerOpen] = React.useState(false);
 
   React.useEffect(()=>{
-    const token = window.sessionStorage.getItem('AUTH_TOKEN');
+    const token = window.sessionStorage.getItem("AUTH_TOKEN");
     if (!!token) {
       const client: any = ChrisAPIClient.getClient();
       client.getUser().then((res: UserResponse) => {
         const user: IUserState = res?.data;
         dispatch({
           type: Types.Login_update,
-          payload: user,
+          payload: user
         });
       })
     }
-  },[dispatch])
+  }, [dispatch])
 
   const { children } = props
 

--- a/src/containers/Layout/PageWrapper.tsx
+++ b/src/containers/Layout/PageWrapper.tsx
@@ -13,7 +13,6 @@ interface WrapperProps {
 const Wrapper = (props: WrapperProps) => {
   
   const { dispatch } = React.useContext(AppContext);
-
   const [isDrawerExpanded, setIsDrawerOpen] = React.useState(false);
 
   React.useEffect(()=>{
@@ -22,8 +21,7 @@ const Wrapper = (props: WrapperProps) => {
       dispatch({
         type: Types.Login_update,
         payload: {
-          username: 'chris',
-          password: 'chris1234'
+          username: window.sessionStorage.getItem('USERNAME'),
         }
       });
     }

--- a/src/containers/Layout/PageWrapper.tsx
+++ b/src/containers/Layout/PageWrapper.tsx
@@ -1,37 +1,16 @@
 import { Page } from "@patternfly/react-core";
 import * as React from "react";
-import { Types } from "../../context/actions/types";
-import { AppContext } from "../../context/context";
 import Header from "./Header";
 import "./layout.scss";
 import NotificationDrawerWrapper from "./NotificationDrawerWrapper";
-import ChrisAPIClient from "../../api/chrisapiclient";
-import { IUserState, UserResponse } from "../../context/reducers/userReducer";
 
 interface WrapperProps {
-  children: React.ReactNode
+  children: React.ReactNode;
 }
 
 const Wrapper = (props: WrapperProps) => {
-  
-  const { dispatch } = React.useContext(AppContext);
   const [isDrawerExpanded, setIsDrawerOpen] = React.useState(false);
-
-  React.useEffect(()=>{
-    const token = window.sessionStorage.getItem("AUTH_TOKEN");
-    if (!!token) {
-      const client: any = ChrisAPIClient.getClient();
-      client.getUser().then((res: UserResponse) => {
-        const user: IUserState = res?.data;
-        dispatch({
-          type: Types.Login_update,
-          payload: user
-        });
-      })
-    }
-  }, [dispatch])
-
-  const { children } = props
+  const { children } = props;
 
   return (
     <Page
@@ -42,7 +21,6 @@ const Wrapper = (props: WrapperProps) => {
       {children}
     </Page>
   );
-
 }
 
 export default Wrapper;

--- a/src/context/reducers/userReducer.tsx
+++ b/src/context/reducers/userReducer.tsx
@@ -7,16 +7,6 @@ export type IUserState = {
   loggedIn?: boolean;
 }
 
-export interface UserResponse {
-  url: string;
-  auth: {
-    token: string;
-  };
-  contentType: string;
-  collection: Object;
-  data: IUserState;
-}
-
 export let initialIUserState = {
   username: '',
   email: '',

--- a/src/context/reducers/userReducer.tsx
+++ b/src/context/reducers/userReducer.tsx
@@ -1,12 +1,25 @@
 import { ActionMap, Types } from "../actions/types";
 
 export type IUserState = {
+  id?: number;
   username: string;
+  email: string;
   loggedIn?: boolean;
+}
+
+export interface UserResponse {
+  url: string;
+  auth: {
+    token: string;
+  };
+  contentType: string;
+  collection: Object;
+  data: IUserState;
 }
 
 export let initialIUserState = {
   username: '',
+  email: '',
   loggedIn: false
 }
 
@@ -27,12 +40,13 @@ export const userReducer = (
     // case Types.
     case Types.Login_update:
       return {
-        username: action.payload.username,
+        ...action.payload,
         loggedIn: true
       }
     case Types.Logout_update:
       return {
         username: '',
+        email: '',
         loggedIn: false
       }
     default:

--- a/src/context/reducers/userReducer.tsx
+++ b/src/context/reducers/userReducer.tsx
@@ -2,13 +2,11 @@ import { ActionMap, Types } from "../actions/types";
 
 export type IUserState = {
   username: string;
-  password: string;
   loggedIn?: boolean;
 }
 
 export let initialIUserState = {
   username: '',
-  password: '',
   loggedIn: false
 }
 
@@ -30,13 +28,11 @@ export const userReducer = (
     case Types.Login_update:
       return {
         username: action.payload.username,
-        password: action.payload.password,
         loggedIn: true
       }
     case Types.Logout_update:
       return {
         username: '',
-        password: '',
         loggedIn: false
       }
     default:

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { History } from 'history';
 import * as React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { AppProvider } from "./context/context";
+import RouterWrapper from "./RouterWrapper";
 import Routes from './routes';
 
 interface AllProps {
@@ -13,7 +14,9 @@ const Main = (props: AllProps) => {
   return (
     <AppProvider>
       <BrowserRouter>
-        <Routes />
+        <RouterWrapper>
+          <Routes />
+        </RouterWrapper>
       </BrowserRouter>
     </AppProvider>
   );

--- a/src/pages/LogIn/components/LoginForm.tsx
+++ b/src/pages/LogIn/components/LoginForm.tsx
@@ -4,6 +4,9 @@ import { useHistory } from "react-router-dom";
 import { Types } from "../../../context/actions/types";
 import { AppContext } from "../../../context/context";
 import { handleLogin } from "../../../services/login";
+import ChrisAPIClient from "../../../api/chrisapiclient";
+import { IUserState } from "../../../context/reducers/userReducer";
+import Client, { User } from "@fnndsc/chrisapi";
 
 const LoginFormComponent = () => {
   const history = useHistory();
@@ -15,23 +18,21 @@ const LoginFormComponent = () => {
 
   const { dispatch } = React.useContext(AppContext);
 
-  const handleSubmit = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    handleLogin(usernameValue, passwordValue)
-    .then(res => {
-      if (res) {
-        dispatch({
-          type: Types.Login_update,
-          payload: {
-            username: usernameValue,
-          }
-        });
-        history.push('/');
-        return;
-      } else {
-        console.log('login failed')
-      }
-    })
+  const handleSubmit = async (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.preventDefault();
+    const isLoginSuccessful = await handleLogin(usernameValue, passwordValue);
+    if (isLoginSuccessful) {
+      const client: Client = ChrisAPIClient.getClient();
+      const res: User = await client.getUser();
+      const user: IUserState = res?.data;
+      dispatch({
+        type: Types.Login_update,
+        payload: user
+      });
+      history.push('/');
+    } else {
+      console.log('login failed');
+    }
   }
 
   return (

--- a/src/pages/LogIn/components/LoginForm.tsx
+++ b/src/pages/LogIn/components/LoginForm.tsx
@@ -8,25 +8,21 @@ import { handleLogin } from "../../../services/login";
 const LoginFormComponent = () => {
   const history = useHistory();
   const [showHelperText] = useState(false);
-  const [usernameValue, setUsernameValue] = useState('chris');
+  const [usernameValue, setUsernameValue] = useState('');
   const [isValidUsername] = useState(true);
-  const [passwordValue, setPasswordValue] = useState('chris1234');
+  const [passwordValue, setPasswordValue] = useState('');
   const [RememberMeClick, setRememberMeClick] = useState(true);
 
   const { dispatch } = React.useContext(AppContext);
 
   const handleSubmit = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    handleLogin({
-      username: usernameValue,
-      password: passwordValue
-    })
+    handleLogin(usernameValue, passwordValue)
     .then(res => {
       if (res) {
         dispatch({
           type: Types.Login_update,
           payload: {
             username: usernameValue,
-            password: passwordValue
           }
         });
         history.push('/');

--- a/src/services/login.tsx
+++ b/src/services/login.tsx
@@ -2,15 +2,11 @@ import Client from "@fnndsc/chrisapi";
 import { IUserState } from '../context/reducers/userReducer';
 
 // returns true if login succeed and false otherwises
-export const handleLogin = async (user: IUserState): Promise<boolean> => {
+export const handleLogin = async (username: string, password: string): Promise<boolean> => {
   try {
     const authURL = `${process.env.REACT_APP_CHRIS_UI_AUTH_URL}`;
-    const username = user.username;
-    const authObj = {
-      password: user.password,
-      username
-    };
-    const res: string = await Client.getAuthToken(authURL, authObj.username, authObj.password)
+
+    const res: string = await Client.getAuthToken(authURL, username, password)
     window.sessionStorage.setItem("AUTH_TOKEN", res);
     window.sessionStorage.setItem("USERNAME", username);
     return true

--- a/src/services/login.tsx
+++ b/src/services/login.tsx
@@ -8,7 +8,6 @@ export const handleLogin = async (username: string, password: string): Promise<b
 
     const res: string = await Client.getAuthToken(authURL, username, password)
     window.sessionStorage.setItem("AUTH_TOKEN", res);
-    window.sessionStorage.setItem("USERNAME", username);
     return true
   } catch (error) {
     return false

--- a/src/services/login.tsx
+++ b/src/services/login.tsx
@@ -1,7 +1,6 @@
 import Client from "@fnndsc/chrisapi";
-import { IUserState } from '../context/reducers/userReducer';
 
-// returns true if login succeed and false otherwises
+// Returns true if login succeeds and false otherwise
 export const handleLogin = async (username: string, password: string): Promise<boolean> => {
   try {
     const authURL = `${process.env.REACT_APP_CHRIS_UI_AUTH_URL}`;

--- a/src/services/login.tsx
+++ b/src/services/login.tsx
@@ -6,7 +6,7 @@ export const handleLogin = async (username: string, password: string): Promise<b
   try {
     const authURL = `${process.env.REACT_APP_CHRIS_UI_AUTH_URL}`;
 
-    const res: string = await Client.getAuthToken(authURL, username, password)
+    const res: string = await Client.getAuthToken(authURL, username, password);
     window.sessionStorage.setItem("AUTH_TOKEN", res);
     return true
   } catch (error) {

--- a/src/types/chrisapi/index.d.ts
+++ b/src/types/chrisapi/index.d.ts
@@ -170,6 +170,14 @@ declare module "@fnndsc/chrisapi" {
     getUploadedFile: (id: number, timeout?: number) => Promise<UploadedFile>;
 
     /**
+     * Get a user resource object for the currently authenticated user.
+     *
+     * @param {number} [timeout=30000] - request timeout
+     * @return {Object} - JS Promise, resolves to a ``User`` object
+     */
+    getUser: (timeout?: number) => Promise<User>;
+
+    /**
      * Get a paginated list of plugins from the REST API given query search
      * parameters. If no search parameters then get the default first page.
      *
@@ -1750,8 +1758,8 @@ declare module "@fnndsc/chrisapi" {
     constructor(url: string, auth: IAuth);
 
     data: {
+      id: number;
       username: string;
-      password: string;
       email: string;
     }
 


### PR DESCRIPTION
### Story Description
COVID-Net UI should support multiple user accounts (leveraging the ChRIS backend). Currently, the UI has a single user hardcoded into the implementation (chris1234); this should be updated to dynamically use the current user logged into the UI.

### Implementation
- Remove all hard-coded user data.
- Remove password property from user store
- Ensure that `ChrisAPIClient tokenIsUnauthorized` is set to `true` when user logs out to prevent auth token from being carried over across multiple sessions.
- Move up code for checking if user is already authenticated to new RouterWrapper component
- Automatically redirect from Login to Dashboard if user already authenticated