### PR TITLE
[CNXC-181] Clear DICOM selections on analysis

### DIFF
--- a/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
+++ b/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
@@ -1,7 +1,7 @@
 import { Drawer, DrawerActions, DrawerCloseButton, DrawerContent, DrawerContentBody, DrawerHead, DrawerPanelContent, Modal } from '@patternfly/react-core';
 import React, { useContext, useState } from "react";
 import { useHistory } from "react-router-dom";
-import { StagingDcmImagesTypes } from '../../context/actions/types';
+import { StagingDcmImagesTypes, CreateAnalysisTypes } from '../../context/actions/types';
 import { AppContext } from '../../context/context';
 import { DcmImage } from "../../context/reducers/dicomImagesReducer";
 import CreateAnalysisService from "../../services/CreateAnalysisService";
@@ -53,9 +53,12 @@ const CreateAnalysisWrapper = () => {
       type: StagingDcmImagesTypes.UpdateStaging,
       payload: { imgs: imagesSelected }
     });
+
+    dispatch({
+      type: CreateAnalysisTypes.Clear_selected_studies_UID
+    })
     history.push("/");
   }
-
 
   const panelContent = (
     <DrawerPanelContent className="rightBar">

--- a/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
+++ b/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
@@ -56,7 +56,7 @@ const CreateAnalysisWrapper = () => {
 
     dispatch({
       type: CreateAnalysisTypes.Clear_selected_studies_UID
-    })
+    });
     history.push("/");
   }
 

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -4,7 +4,7 @@ import { RouteComponentProps } from "react-router-dom";
 import { CreateAnalysisSection } from "../../components/CreateAnalysis/CreateAnalysis";
 import PastAnalysisTable from "../../components/pastAnalysis/PastAnalysisTable";
 import Wrapper from "../../containers/Layout/PageWrapper";
-import { AnalysisTypes, CreateAnalysisTypes, NotificationActionTypes, StagingDcmImagesTypes } from "../../context/actions/types";
+import { AnalysisTypes, NotificationActionTypes, StagingDcmImagesTypes } from "../../context/actions/types";
 import { AppContext } from "../../context/context";
 import CreateAnalysisService from "../../services/CreateAnalysisService";
 
@@ -23,10 +23,6 @@ const DashboardPage: React.FC<AllProps> = () => {
         dispatch({
           type: StagingDcmImagesTypes.UpdateStaging,
           payload: { imgs: [] }
-        })
-        // clear the selecting images step in create analysis
-        dispatch({
-          type: CreateAnalysisTypes.Clear_selected_studies_UID
         })
         dispatch({
           type: AnalysisTypes.Update_are_new_imgs_available,


### PR DESCRIPTION
### Problem Statement
When a user selects scans and starts the analysis and then returns back to the same patient to start another analysis but for other scans, the previous scans are still selected.

### Implementation
Dispatch `Clear_selected_studies_UID` in `submitAnalysis()` as opposed to after analyses are completed.

### Scenario
Steps to Reproduce
1. Log into COVIDNet Portal
2. Enter a Patient MRN and press Continue
3. Select an XRay or CT scan
4. Click Analyze to start the analysis
5. A user gets redirected to dashboard
6. Navigate to a patient again in order to start another analysis

Actual Behaviour
- DICOMs remain selected on Create Analysis page until the previous analyses are completed.

Expected Behaviour
- DICOMs should immediately be de-selected upon analyzing.