### PR TITLE
[CNXC-244] Fix styling of SeriesTable header

### DIFF
--- a/src/components/pastAnalysis/seriesTable.tsx
+++ b/src/components/pastAnalysis/seriesTable.tsx
@@ -16,7 +16,7 @@ export const isLargestNumber = (num: number | null | undefined, numArray: Map<st
   if (num && numArray) {
     let maxValue: number = 0;
     numArray.forEach((value: number) => {
-    maxValue = (!maxValue || maxValue < value) ? value : maxValue;
+      maxValue = (!maxValue || maxValue < value) ? value : maxValue;
     })
 
     return num === maxValue;
@@ -31,8 +31,8 @@ const SeriesTable: React.FC<SeriesTableProps> = ({ studyInstance, isProcessing }
   const { dispatch } = useContext(AppContext);
   const { series: analysisList } = studyInstance;
   let titles = [
-    { title: (<span><br />Preview<span className='classificationText'>&nbsp;</span></span>) },
-    { title: (<span><br />Image<span className='classificationText'>&nbsp;</span></span>) }
+    { title: (<span className='classificationText'><br />Preview</span>) },
+    { title: (<span className='classificationText'><br />Image</span>) }
   ];
 
   analysisList[0]?.classifications.forEach((value: number, key: string) => {
@@ -40,14 +40,14 @@ const SeriesTable: React.FC<SeriesTableProps> = ({ studyInstance, isProcessing }
   });
 
   titles.push({ title: (<span className='classificationText'><span>Geographic<br />Severity</span></span>) },
-              { title: (<span className='classificationText'><span>Opacity<br />Extent</span></span>) },
-              { title: (<span></span>) });
+    { title: (<span className='classificationText'><span>Opacity<br />Extent</span></span>) },
+    { title: (<span></span>) });
 
   const columns = titles;
 
   const rows = analysisList.map((analysis: ISeries, index: number) => {
     let analysisCells: any = [
-      { title: (analysis.imageUrl ? <div><b><img src={analysis.imageUrl} className="thumbnail" /></b></div> : <div><PreviewNotAvailable /></div>) },
+      { title: (analysis.imageUrl ? <div><img src={analysis.imageUrl} className="thumbnail" /></div> : <div><PreviewNotAvailable /></div>) },
       { title: (<div><b>{analysis.imageName.split('/').pop()}</b></div>) }
     ];
 
@@ -55,16 +55,17 @@ const SeriesTable: React.FC<SeriesTableProps> = ({ studyInstance, isProcessing }
       analysisCells.push({
         title: (<PredictionCircle key={key}
           largeCircle={isLargestNumber(value, analysis.classifications)}
-          predictionNumber={value} />)});
-    });
-  
-      analysisCells.push({
-        title: `${analysis.geographic ? `${analysis.geographic.severity}` : 'N/A'}`
-      }, {
-        title: `${analysis.opacity ? `${analysis.opacity.extentScore}` : 'N/A'}`
-      }, {
-        title: (<Button variant="secondary" onClick={() => viewImage(index)} isDisabled={isProcessing}>View</Button>)
+          predictionNumber={value} />)
       });
+    });
+
+    analysisCells.push({
+      title: `${analysis.geographic ? `${analysis.geographic.severity}` : 'N/A'}`
+    }, {
+      title: `${analysis.opacity ? `${analysis.opacity.extentScore}` : 'N/A'}`
+    }, {
+      title: (<Button variant="secondary" onClick={() => viewImage(index)} isDisabled={isProcessing}>View</Button>)
+    });
 
     return { cells: analysisCells };
   });


### PR DESCRIPTION
### Problem Statement
There is some inconsistency in the formatting of the headers of the SeriesTable. The first 2 columns have headers in black, while the rest are grey.
![Screenshot from 2021-03-18 16-28-03](https://user-images.githubusercontent.com/24356368/111693966-a5a2f180-8807-11eb-92b1-508ad8291af1.png)


### Implementation
The SCSS class for styling the headers as grey were applied to the first 2 header elements.