### PR TITLE
[CNXC-230] Add UI for invalid login credentials + Remove "Remember me" option

### DIFF
--- a/src/pages/LogIn/components/LoginForm.tsx
+++ b/src/pages/LogIn/components/LoginForm.tsx
@@ -10,7 +10,6 @@ import Client, { User } from "@fnndsc/chrisapi";
 
 const LoginFormComponent = () => {
   const history = useHistory();
-  const [helperText, setHelperText] = useState("");
   const [usernameValue, setUsernameValue] = useState("");
   const [passwordValue, setPasswordValue] = useState("");
   const [isValidCredentials, setIsValidCredentials] = useState(true);
@@ -23,7 +22,6 @@ const LoginFormComponent = () => {
     const isLoginSuccessful = await handleLogin(usernameValue, passwordValue);
     if (isLoginSuccessful) {
       setIsValidCredentials(true);
-      setHelperText("");
       const client: Client = ChrisAPIClient.getClient();
       const res: User = await client.getUser();
       const user: IUserState = res?.data;
@@ -34,14 +32,13 @@ const LoginFormComponent = () => {
       history.push('/');
     } else {
       setIsValidCredentials(false);
-      setHelperText("Invalid username or password.");
     }
   }
 
   return (
     <LoginForm
-      showHelperText={!!helperText}
-      helperText={helperText}
+      showHelperText={!isValidCredentials}
+      helperText="Invalid username or password."
       usernameLabel="Username"
       usernameValue={usernameValue}
       onChangeUsername={(val) => setUsernameValue(val)}

--- a/src/pages/LogIn/components/LoginForm.tsx
+++ b/src/pages/LogIn/components/LoginForm.tsx
@@ -10,18 +10,20 @@ import Client, { User } from "@fnndsc/chrisapi";
 
 const LoginFormComponent = () => {
   const history = useHistory();
-  const [showHelperText] = useState(false);
-  const [usernameValue, setUsernameValue] = useState('');
-  const [isValidUsername] = useState(true);
-  const [passwordValue, setPasswordValue] = useState('');
-  const [RememberMeClick, setRememberMeClick] = useState(true);
+  const [helperText, setHelperText] = useState("");
+  const [usernameValue, setUsernameValue] = useState("");
+  const [passwordValue, setPasswordValue] = useState("");
+  const [isValidCredentials, setIsValidCredentials] = useState(true);
 
   const { dispatch } = React.useContext(AppContext);
 
   const handleSubmit = async (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.preventDefault();
+
     const isLoginSuccessful = await handleLogin(usernameValue, passwordValue);
     if (isLoginSuccessful) {
+      setIsValidCredentials(true);
+      setHelperText("");
       const client: Client = ChrisAPIClient.getClient();
       const res: User = await client.getUser();
       const user: IUserState = res?.data;
@@ -31,25 +33,23 @@ const LoginFormComponent = () => {
       });
       history.push('/');
     } else {
-      console.log('login failed');
+      setIsValidCredentials(false);
+      setHelperText("Invalid username or password.");
     }
   }
 
   return (
     <LoginForm
-      showHelperText={showHelperText}
-      helperText="Invalid login credentials."
+      showHelperText={!!helperText}
+      helperText={helperText}
       usernameLabel="Username"
       usernameValue={usernameValue}
       onChangeUsername={(val) => setUsernameValue(val)}
-      isValidUsername={isValidUsername}
+      isValidUsername={isValidCredentials}
       passwordLabel="Password"
       passwordValue={passwordValue}
       onChangePassword={(val) => setPasswordValue(val)}
-      isValidPassword={true}
-      rememberMeLabel="Keep me logged in for 30 days."
-      isRememberMeChecked={RememberMeClick}
-      onChangeRememberMe={() => setRememberMeClick(!RememberMeClick)}
+      isValidPassword={isValidCredentials}
       onLoginButtonClick={handleSubmit}
     />
   );


### PR DESCRIPTION
### Problem Statement
- Currently, when the user provides invalid user credentials on the Login page and tries to log in, there are no visual indicators to inform the user.
- The "Remember me" option is present on the login component but is not being used.

### Implementation
- Utilized the `helperText` and `isValid` props provided by the PatternFly LoginForm component to display login errors to the user.
- Removed the "Remember me" option