### PR TITLE
[CNXC-202] Fix responsiveness issues with Dicom Viewer

### DIFF
--- a/src/assets/scss/components/DicomImageViewer.scss
+++ b/src/assets/scss/components/DicomImageViewer.scss
@@ -108,7 +108,7 @@ $opacityLevel: 0.75;
 }
 
 .expandedBottom {
-  height: 15em;
+  height: 13em;
   overflow: hidden;
   transition: height 1s;
 }

--- a/src/assets/scss/components/DicomImageViewer.scss
+++ b/src/assets/scss/components/DicomImageViewer.scss
@@ -108,14 +108,14 @@ $opacityLevel: 0.75;
 }
 
 .expandedBottom {
+  height: 15em;
+  overflow: hidden;
   transition: height 1s;
-  height: 25vh;
 }
 
 .collapsedBottom {
-  height: 3vh;
+  height: 2em;
   transition: height 1s;
-  // overflow: hidden;
 }
 
 .imgViewer {

--- a/src/assets/scss/components/DicomImageViewer.scss
+++ b/src/assets/scss/components/DicomImageViewer.scss
@@ -14,9 +14,10 @@ $opacityLevel: 0.75;
   width: 100vw;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
   background: rgba(0, 0, 0, $opacityLevel); //$imgViewerBackgroundColour;
   color: $textColor;
-  height: 8vh;
+  height: auto;
   button {
     margin-left: 1rem;
     height: 8vh;

--- a/src/assets/scss/components/DicomImageViewer.scss
+++ b/src/assets/scss/components/DicomImageViewer.scss
@@ -156,6 +156,7 @@ $collapse-button-height: 2em;
 }
 
 .bottomInfoBox {
+  flex-grow: 1;
   justify-content: space-around;
   flex-wrap: wrap;
 }

--- a/src/assets/scss/components/DicomImageViewer.scss
+++ b/src/assets/scss/components/DicomImageViewer.scss
@@ -87,6 +87,7 @@ $opacityLevel: 0.75;
     @extend .flex_col;
     align-items: center;
     justify-content: flex-end;
+    margin-right: 1em;
 
     tspan {
       fill: $textColor !important;
@@ -96,7 +97,7 @@ $opacityLevel: 0.75;
     padding-left: 2rem;
   }
   .padding-l-2rem {
-    padding-left: 2rem;
+    padding: 0 0 2em 2em;
   }
   span {
     color: $textColor;
@@ -108,7 +109,7 @@ $opacityLevel: 0.75;
 }
 
 .expandedBottom {
-  height: 13em;
+  height: auto;
   overflow: hidden;
   transition: height 1s;
 }
@@ -150,6 +151,7 @@ $opacityLevel: 0.75;
 
 .bottomInfoBox {
   justify-content: space-around;
+  flex-wrap: wrap;
 }
 
 .displayNone {

--- a/src/assets/scss/components/DicomImageViewer.scss
+++ b/src/assets/scss/components/DicomImageViewer.scss
@@ -2,6 +2,7 @@ $imgViewerBackgroundColour: black;
 $textColor: white;
 $GreyTextColor: #868686;
 $opacityLevel: 0.75;
+$collapse-button-height: 2em;
 
 .invertImg {
   filter: invert(1) brightness(200%) !important;
@@ -83,6 +84,7 @@ $opacityLevel: 0.75;
     position: relative;
     justify-content: flex-end;
     margin-right: 1.5rem;
+    height: $collapse-button-height;
   }
   .PredictionArea {
     @extend .flex_col;
@@ -112,12 +114,14 @@ $opacityLevel: 0.75;
 .expandedBottom {
   height: auto;
   overflow: hidden;
-  transition: height 1s;
+  transform: translate(0, 0);
+  transition: transform 1s;
 }
 
 .collapsedBottom {
-  height: 2em;
-  transition: height 1s;
+  height: auto;
+  transform: translate(0, calc(100% - #{$collapse-button-height}));
+  transition: transform 1s;
 }
 
 .imgViewer {
@@ -126,6 +130,7 @@ $opacityLevel: 0.75;
   height: 100vh;
   justify-content: space-between;
   background-color: $imgViewerBackgroundColour;
+  overflow: hidden;
 }
 
 .pointer {

--- a/src/components/dicmViewer/dicomViewerBottomBox.tsx
+++ b/src/components/dicmViewer/dicomViewerBottomBox.tsx
@@ -79,7 +79,7 @@ const DicomViewerBottomBox = () => {
           {!isBottomHided ? (<i className="fas fa-angle-down"></i>) : (<i className="fas fa-angle-up"></i>)}
         </span>
       </div>
-      <div className={`flex_row bottomInfoBox ${!isBottomHided ? '' : 'displayNone'}`}>
+      <div className={`flex_row bottomInfoBox`}>
         <div className="padding-l-2rem">
           <h2><span><i className="pf-icon pf-icon-info"></i></span></h2>
         </div>

--- a/src/components/dicmViewer/dicomViewerBottomBox.tsx
+++ b/src/components/dicmViewer/dicomViewerBottomBox.tsx
@@ -81,7 +81,7 @@ const DicomViewerBottomBox = () => {
       </div>
       <div className="flex_row">
         <div className="padding-l-2rem">
-            <h2><span><i className="pf-icon pf-icon-info"></i></span></h2>
+          <h2><span><i className="pf-icon pf-icon-info"></i></span></h2>
         </div>
         <div className="flex_row bottomInfoBox">
           <div className="padding-l-2rem">

--- a/src/components/dicmViewer/dicomViewerBottomBox.tsx
+++ b/src/components/dicmViewer/dicomViewerBottomBox.tsx
@@ -79,34 +79,36 @@ const DicomViewerBottomBox = () => {
           {!isBottomHided ? (<i className="fas fa-angle-down"></i>) : (<i className="fas fa-angle-up"></i>)}
         </span>
       </div>
-      <div className={`flex_row bottomInfoBox`}>
+      <div className="flex_row">
         <div className="padding-l-2rem">
-          <h2><span><i className="pf-icon pf-icon-info"></i></span></h2>
+            <h2><span><i className="pf-icon pf-icon-info"></i></span></h2>
         </div>
-        <div className="padding-l-2rem">
-          <h2>{studyInstance?.dcmImage.PatientName}</h2>
-          <p><span>MRN</span> #{studyInstance?.dcmImage.PatientID}</p>
-          <p><span>DOB</span> {studyInstance?.dcmImage.PatientBirthDate}</p>
-          <p><span>GENDER</span> {studyInstance ? formatGender(studyInstance.dcmImage.PatientSex) : ''}</p>
-        </div>
-        <div className="padding-l-2rem">
-          <h2>{studyInstance?.dcmImage.StudyDescription}</h2>
-          <p><span>DATE</span> {studyInstance?.analysisCreated}</p>
-          <p><span>AETITLE</span> Station1234</p>
-          <p><span>MODALITY</span> XRAY</p>
-        </div>
-        <div className="predictions padding-l-2rem">
-          <span className='logo-text'>COVID-Net</span>
-          <div className="flex_row">
-          
-            {generateDisplayCircles(imageDetail)}
+        <div className="flex_row bottomInfoBox">
+          <div className="padding-l-2rem">
+            <h2>{studyInstance?.dcmImage.PatientName}</h2>
+            <p><span>MRN</span> #{studyInstance?.dcmImage.PatientID}</p>
+            <p><span>DOB</span> {studyInstance?.dcmImage.PatientBirthDate}</p>
+            <p><span>GENDER</span> {studyInstance ? formatGender(studyInstance.dcmImage.PatientSex) : ''}</p>
+          </div>
+          <div className="padding-l-2rem">
+            <h2>{studyInstance?.dcmImage.StudyDescription}</h2>
+            <p><span>DATE</span> {studyInstance?.analysisCreated}</p>
+            <p><span>AETITLE</span> Station1234</p>
+            <p><span>MODALITY</span> XRAY</p>
+          </div>
+          <div className="predictions padding-l-2rem">
+            <span className='logo-text'>COVID-Net</span>
+            <div className="flex_row">
+            
+              {generateDisplayCircles(imageDetail)}
 
-            <div className="padding-l-2rem">
-              <p><span>GEOGRAPHIC SEVERITY</span>&nbsp;{geoOpacityNumbers(imageDetail, 'geographic', 'severity')}</p>
-              <p><span>GEOGRAPHIC EXTENT</span>&nbsp;{geoOpacityNumbers(imageDetail, 'geographic', 'extentScore')}</p>
-              <br />
-              <p><span>OPACITY SEVERITY</span>&nbsp;{geoOpacityNumbers(imageDetail, 'opacity', 'severity')}</p>
-              <p><span>OPACITY EXTENT</span>&nbsp;{geoOpacityNumbers(imageDetail, 'opacity', 'extentScore')}</p>
+              <div className="padding-l-2rem">
+                <p><span>GEOGRAPHIC SEVERITY</span>&nbsp;{geoOpacityNumbers(imageDetail, 'geographic', 'severity')}</p>
+                <p><span>GEOGRAPHIC EXTENT</span>&nbsp;{geoOpacityNumbers(imageDetail, 'geographic', 'extentScore')}</p>
+                <br />
+                <p><span>OPACITY SEVERITY</span>&nbsp;{geoOpacityNumbers(imageDetail, 'opacity', 'severity')}</p>
+                <p><span>OPACITY EXTENT</span>&nbsp;{geoOpacityNumbers(imageDetail, 'opacity', 'extentScore')}</p>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Problem Statement
The bottom box on the Dicom Viewer page does not scale well. Its height should scale along with its contents.
![Screenshot from 2021-03-18 17-12-12](https://user-images.githubusercontent.com/24356368/111698342-18fb3200-880d-11eb-9826-ef4aed4ce0cb.png)


### Implementation
- `em` units were used instead of `vh` to allow for responsiveness when zooming in and out of the page
- `flex` property was used for responsiveness on narrower screens