### PR TITLE
[CNXC-247] Re-running Current Analyses when Routing Back to Dashboard

### DIFF
--- a/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
+++ b/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
@@ -22,7 +22,7 @@ const CreateAnalysisWrapper = () => {
       setIsModalOpen(true);
       return;
     }
-    
+
     if (process.env.REACT_APP_CHRIS_UI_DICOM_SOURCE === 'pacs') {
       // Send request to have DICOM files pushed from PACS server to pypx
       const retrievePromises: Promise<boolean>[] = [];
@@ -58,22 +58,22 @@ const CreateAnalysisWrapper = () => {
       type: CreateAnalysisTypes.Clear_selected_studies_UID
     });
 
-       // Processing the images
-       CreateAnalysisService.analyzeImages(imagesSelected, models.xrayModel, models.ctModel) // Passing selected models to Chris_Integration for image analysis
-       .then((notifications) => {
-         dispatch({
-           type: StagingDcmImagesTypes.UpdateStaging,
-           payload: { imgs: [] }
-         })
-         dispatch({
-           type: AnalysisTypes.Update_are_new_imgs_available,
-           payload: { isAvailable: true }
-         });
-         dispatch({
-           type: NotificationActionTypes.SEND,
-           payload: { notifications }
-         })
-       });
+    // Processing the images
+    CreateAnalysisService.analyzeImages(imagesSelected, models.xrayModel, models.ctModel) // Passing selected models to Chris_Integration for image analysis
+      .then((notifications) => {
+        dispatch({
+          type: StagingDcmImagesTypes.UpdateStaging,
+          payload: { imgs: [] }
+        });
+        dispatch({
+          type: AnalysisTypes.Update_are_new_imgs_available,
+          payload: { isAvailable: true }
+        });
+        dispatch({
+          type: NotificationActionTypes.SEND,
+          payload: { notifications }
+        });
+      });
 
     history.push("/");
   }

--- a/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
+++ b/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
@@ -1,14 +1,14 @@
-import { Drawer, DrawerActions, DrawerCloseButton, DrawerContent, DrawerContentBody, DrawerHead, DrawerPanelContent, Modal } from '@patternfly/react-core';
+import { Drawer, DrawerActions, DrawerCloseButton, DrawerContent, DrawerContentBody, DrawerHead, DrawerPanelContent, Modal } from "@patternfly/react-core";
 import React, { useContext, useState } from "react";
 import { useHistory } from "react-router-dom";
-import { StagingDcmImagesTypes, CreateAnalysisTypes, AnalysisTypes, NotificationActionTypes } from '../../context/actions/types';
-import { AppContext } from '../../context/context';
+import { StagingDcmImagesTypes, CreateAnalysisTypes, AnalysisTypes, NotificationActionTypes } from "../../context/actions/types";
+import { AppContext } from "../../context/context";
 import { DcmImage } from "../../context/reducers/dicomImagesReducer";
 import CreateAnalysisService from "../../services/CreateAnalysisService";
-import ConfirmAnalysis from './ConfirmAnalysis';
+import ConfirmAnalysis from "./ConfirmAnalysis";
 import CreateAnalysisDetail from "./CreateAnalysisDetail";
-import pacs_integration from '../../services/pacs_integration';
-import chris_integration from '../../services/chris_integration';
+import pacs_integration from "../../services/pacs_integration";
+import chris_integration from "../../services/chris_integration";
 
 const CreateAnalysisWrapper = () => {
   const { state: { dcmImages, models, createAnalysis: { selectedStudyUIDs } }, dispatch } = useContext(AppContext);

--- a/src/pages/CreateAnalysisPage/CreateAnalysisPage.tsx
+++ b/src/pages/CreateAnalysisPage/CreateAnalysisPage.tsx
@@ -7,7 +7,7 @@ import { AppContext } from "../../context/context";
 import Error from "../../shared/error";
 
 const CreateAnalysisPage = () => {
-  const { state: {dcmImages} } = React.useContext(AppContext);
+  const { state: { dcmImages } } = React.useContext(AppContext);
 
   return (
     <div className="encapsulation">

--- a/src/pages/CreateAnalysisPage/CreateAnalysisPage.tsx
+++ b/src/pages/CreateAnalysisPage/CreateAnalysisPage.tsx
@@ -7,8 +7,7 @@ import { AppContext } from "../../context/context";
 import Error from "../../shared/error";
 
 const CreateAnalysisPage = () => {
-  const { state } = React.useContext(AppContext);
-  const { dcmImages } = state;
+  const { state: {dcmImages} } = React.useContext(AppContext);
 
   return (
     <div className="encapsulation">

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { PageSection, PageSectionVariants } from "@patternfly/react-core";
-import React from "react";
+import React, { useEffect } from "react";
 import { RouteComponentProps } from "react-router-dom";
 import { CreateAnalysisSection } from "../../components/CreateAnalysis/CreateAnalysis";
 import PastAnalysisTable from "../../components/pastAnalysis/PastAnalysisTable";
@@ -8,7 +8,11 @@ import Wrapper from "../../containers/Layout/PageWrapper";
 type AllProps = RouteComponentProps;
 
 const DashboardPage: React.FC<AllProps> = () => {
-  document.title = "Analysis - COVID-Net UI";
+
+  useEffect(()=> {
+    document.title = "Analysis - COVID-Net UI";
+  }, [])
+  
 
   return (
     <Wrapper>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -16,23 +16,6 @@ const DashboardPage: React.FC<AllProps> = () => {
   useEffect(() => {
     document.title = "Analysis - COVID-Net UI";
     if (stagingDcmImages.length <= 0) return;
-
-    // Processing the images
-    CreateAnalysisService.analyzeImages(stagingDcmImages, models.xrayModel, models.ctModel) // Passing selected models to Chris_Integration for image analysis
-      .then((notifications) => {
-        dispatch({
-          type: StagingDcmImagesTypes.UpdateStaging,
-          payload: { imgs: [] }
-        })
-        dispatch({
-          type: AnalysisTypes.Update_are_new_imgs_available,
-          payload: { isAvailable: true }
-        });
-        dispatch({
-          type: NotificationActionTypes.SEND,
-          payload: { notifications }
-        })
-      });
   }, [dispatch, stagingDcmImages, models.ctModel, models.xrayModel]);
 
   return (

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,22 +1,14 @@
 import { PageSection, PageSectionVariants } from "@patternfly/react-core";
-import React, { useContext, useEffect } from "react";
+import React from "react";
 import { RouteComponentProps } from "react-router-dom";
 import { CreateAnalysisSection } from "../../components/CreateAnalysis/CreateAnalysis";
 import PastAnalysisTable from "../../components/pastAnalysis/PastAnalysisTable";
 import Wrapper from "../../containers/Layout/PageWrapper";
-import { AnalysisTypes, NotificationActionTypes, StagingDcmImagesTypes } from "../../context/actions/types";
-import { AppContext } from "../../context/context";
-import CreateAnalysisService from "../../services/CreateAnalysisService";
 
 type AllProps = RouteComponentProps;
 
 const DashboardPage: React.FC<AllProps> = () => {
-  const { state: { stagingDcmImages, models }, dispatch } = useContext(AppContext);
-
-  useEffect(() => {
-    document.title = "Analysis - COVID-Net UI";
-    if (stagingDcmImages.length <= 0) return;
-  }, [dispatch, stagingDcmImages, models.ctModel, models.xrayModel]);
+  document.title = "Analysis - COVID-Net UI";
 
   return (
     <Wrapper>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -11,7 +11,7 @@ const DashboardPage: React.FC<AllProps> = () => {
 
   useEffect(()=> {
     document.title = "Analysis - COVID-Net UI";
-  }, [])
+  }, []);
   
 
   return (


### PR DESCRIPTION
### Problem Statement
Currently, after starting an analysis, COVID-Net re-runs the same analysis if the user goes to `Create Analysis` and routes back to `Dashboard` (before the previous analysis has finished)

### Implementation
Refactored code to create the analysis in CreateAnalysis, instead of Dashboard. Doing this, this resolves the issue of having mixed concerns and a bug of triggering current analyses to re-run when routing back to Dashboard repeatedly. Code now separates concerns and resolves the bug