### PR TITLE
[CNXC-249] Patient MRN not displaying after search/re-routing

### DIFF
--- a/src/components/CreateAnalysis/CreateAnalysisDetail.tsx
+++ b/src/components/CreateAnalysis/CreateAnalysisDetail.tsx
@@ -32,7 +32,7 @@ const CreateAnalysisDetail: React.FC<CreateAnalysisDetailProps> = ({ setIsExpand
       setPatientBirthdate(image.PatientBirthDate);
       setPatientSex(image.PatientSex);
     }
-  }, [dcmImages, createAnalysis]);
+  }, [dcmImages]);
 
   const studyInstances: StudyInstance[] = CreateAnalysisService.extractStudyInstances(dcmImages?.filteredDcmImages);
   const numOfSelectedImages: number = CreateAnalysisService.findTotalImages(createAnalysis.selectedStudyUIDs);

--- a/src/components/CreateAnalysis/CreateAnalysisDetail.tsx
+++ b/src/components/CreateAnalysis/CreateAnalysisDetail.tsx
@@ -18,6 +18,7 @@ interface CreateAnalysisDetailProps {
 }
 
 const CreateAnalysisDetail: React.FC<CreateAnalysisDetailProps> = ({ setIsExpanded, submitAnalysis }) => {
+  
   const { state: { createAnalysis, dcmImages } } = useContext(AppContext);
   const [isXray, setIsXray] = useState(false);
   const [patientName, setPatientName] = useState("");
@@ -31,7 +32,7 @@ const CreateAnalysisDetail: React.FC<CreateAnalysisDetailProps> = ({ setIsExpand
       setPatientBirthdate(image.PatientBirthDate);
       setPatientSex(image.PatientSex);
     }
-  }, [dcmImages]);
+  }, [dcmImages, createAnalysis]);
 
   const studyInstances: StudyInstance[] = CreateAnalysisService.extractStudyInstances(dcmImages?.filteredDcmImages);
   const numOfSelectedImages: number = CreateAnalysisService.findTotalImages(createAnalysis.selectedStudyUIDs);

--- a/src/components/PatientLookup.tsx
+++ b/src/components/PatientLookup.tsx
@@ -1,9 +1,6 @@
 import {
   Button, Dropdown,
-
   DropdownItem, DropdownToggle,
-
-
   TextInput
 } from '@patternfly/react-core';
 import React, { useContext, useState } from "react";
@@ -25,9 +22,9 @@ interface PatientLookupProps {
 }
 
 const PatientLookup = (props: PatientLookupProps) => {
-  const { dispatch } = useContext(AppContext);
+  const { state: {createAnalysis: {patientID}}, dispatch } = useContext(AppContext);
   const [privacyLevel, setPrivacyLevel] = useState(PrivacyLevel.ANONYMIZE_ALL_DATA)
-  const [patientID, setPatientID] = useState<string>("");
+  const [patientIDInput, setPatientIDInput] = useState<string>((patientID && !props.isOnDashboard) ? patientID : "");
   const history = useHistory();
 
   const [isDropDownOpen, setDropDownOpen] = React.useState(false);
@@ -46,14 +43,14 @@ const PatientLookup = (props: PatientLookupProps) => {
     dispatch({
       type: CreateAnalysisTypes.Update_patient_ID,
       payload: {
-        patientID
+        patientID: patientIDInput
       }
     });
 
     try {
       const dcmImages = process.env.REACT_APP_CHRIS_UI_DICOM_SOURCE === 'pacs' ?
-        await pacs_integration.queryPatientFiles(patientID) :
-        await chris_integration.fetchPacFiles(patientID);
+        await pacs_integration.queryPatientFiles(patientIDInput) :
+        await chris_integration.fetchPacFiles(patientIDInput);
 
       dispatch({
         type: DicomImagesTypes.Update_all_images,
@@ -70,7 +67,7 @@ const PatientLookup = (props: PatientLookupProps) => {
           payload: {
             studyUID: studyInstances[0].studyInstanceUID
           }
-        })
+        });
       }
     } catch (err) {
       console.error(err);
@@ -104,7 +101,7 @@ const PatientLookup = (props: PatientLookupProps) => {
       <div className="InputRow">
         <div className="InputRowField">
           <label>Patient MRN</label>
-          <TextInput value={patientID} type="text" onChange={setPatientID} aria-label="text input example" />
+          <TextInput value={patientIDInput} type="text" onChange={setPatientIDInput} aria-label="text input example" />
         </div>
         <div className="InputRowField">
           <label>Privacy Level</label>

--- a/src/components/PatientLookup.tsx
+++ b/src/components/PatientLookup.tsx
@@ -104,7 +104,7 @@ const PatientLookup: React.FC<PatientLookupProps> = ({ isOnDashboard }) => {
         <form onSubmit={newLookup} className="form-display">
           <div className="InputRowField">
             <label>Patient MRN</label>
-            <TextInput value={patientID} type="text" onChange={setPatientIDInput} aria-label="MRN Search Field" />
+            <TextInput value={patientIDInput} type="text" onChange={setPatientIDInput} aria-label="MRN Search Field" />
           </div>
           <div className="InputRowField">
             <label>Privacy Level</label>

--- a/src/components/PatientLookup.tsx
+++ b/src/components/PatientLookup.tsx
@@ -32,7 +32,7 @@ const PatientLookup = (props: PatientLookupProps) => {
 
   const [isDropDownOpen, setDropDownOpen] = React.useState(false);
 
-  const onSelect = (value: any) => {
+  const onSelect = () => {
     setDropDownOpen(!isDropDownOpen);
     onFocus();
   }

--- a/src/components/PatientLookup.tsx
+++ b/src/components/PatientLookup.tsx
@@ -22,7 +22,7 @@ interface PatientLookupProps {
 }
 
 const PatientLookup = (props: PatientLookupProps) => {
-  const { state: {createAnalysis: { patientID }}, dispatch } = useContext(AppContext);
+  const { state: { createAnalysis: { patientID }}, dispatch } = useContext(AppContext);
   const [privacyLevel, setPrivacyLevel] = useState(PrivacyLevel.ANONYMIZE_ALL_DATA)
   const [patientIDInput, setPatientIDInput] = useState<string>((patientID && !props.isOnDashboard) ? patientID : "");
   const history = useHistory();

--- a/src/components/PatientLookup.tsx
+++ b/src/components/PatientLookup.tsx
@@ -22,7 +22,7 @@ interface PatientLookupProps {
 }
 
 const PatientLookup = (props: PatientLookupProps) => {
-  const { state: {createAnalysis: {patientID}}, dispatch } = useContext(AppContext);
+  const { state: {createAnalysis: { patientID }}, dispatch } = useContext(AppContext);
   const [privacyLevel, setPrivacyLevel] = useState(PrivacyLevel.ANONYMIZE_ALL_DATA)
   const [patientIDInput, setPatientIDInput] = useState<string>((patientID && !props.isOnDashboard) ? patientID : "");
   const history = useHistory();


### PR DESCRIPTION
### Problem Statement
Currently, the patient MRN box is empty after performing a search, and also after routing back to the Create Analysis page.

### Implementation
Added createAnalysis store into CreateAnalysisDetail useEffect's dependency to now update and display the current patient MRN correctly, and also keep/store the value when re-routing back to the Create Analysis page during the same session. The value now stays in sync with Create Analysis page patient content.