### PR TITLE
[CNXC-245] Updating State on Unmounted Component in Dashboard (Memory Leak Bug)

### DIFF
--- a/src/components/PatientLookup.tsx
+++ b/src/components/PatientLookup.tsx
@@ -1,9 +1,6 @@
 import {
   Button, Dropdown,
-
   DropdownItem, DropdownToggle,
-
-
   TextInput
 } from '@patternfly/react-core';
 import React, { useContext, useState } from "react";

--- a/src/components/pastAnalysis/PastAnalysisTable.tsx
+++ b/src/components/pastAnalysis/PastAnalysisTable.tsx
@@ -90,33 +90,34 @@ const PastAnalysisTable = () => {
   useEffect(() => {
     let isMounted = true;
 
-    (async () => {
-      setLoading(true);
-      const { maxFeedId, page, lastOffset, storedPages } = tableStates;
+    if (isMounted) {
+      (async () => {
+        setLoading(true);
+        const { maxFeedId, page, lastOffset, storedPages } = tableStates;
 
-      // Update the maxFeedId when the PastAnalysisTable first mounts
-      if (maxFeedId === -1) {
-        updateMaxFeedId();
-        return;
-      }
+        // Update the maxFeedId when the PastAnalysisTable first mounts
+        if (maxFeedId === -1) {
+          updateMaxFeedId();
+          return;
+        }
 
-      // Get rows for analysis currently processing
-      const imagesAnalyzing: StudyInstanceWithSeries[] = PastAnalysisService.groupDcmImagesToStudyInstances(stagingDcmImages);
-      const numAnalyzing = imagesAnalyzing.length;
+        // Get rows for analysis currently processing
+        const imagesAnalyzing: StudyInstanceWithSeries[] = PastAnalysisService.groupDcmImagesToStudyInstances(stagingDcmImages);
+        const numAnalyzing = imagesAnalyzing.length;
 
-      // Calculate number of past analysis rows to fetch, given the number of processing rows to display on current page
-      let fetchSize;
-      if (Math.floor(numAnalyzing / perpage) > page) { // There are enough processing rows to fill entire page, so don't fetch any past results
-        fetchSize = 0;
-      } else if (Math.floor(numAnalyzing / perpage) === page) { // Processing rows partially fill the page, fill rest of page with past results
-        fetchSize = perpage - (numAnalyzing % perpage);
-      } else { // No processing rows on current page, fill entire page with past results
-        fetchSize = perpage;
-      }
-      // Slice the array of processing rows to display on current page
-      const processingRows = imagesAnalyzing.slice(page * perpage, (page + 1) * perpage);
+        // Calculate number of past analysis rows to fetch, given the number of processing rows to display on current page
+        let fetchSize;
+        if (Math.floor(numAnalyzing / perpage) > page) { // There are enough processing rows to fill entire page, so don't fetch any past results
+          fetchSize = 0;
+        } else if (Math.floor(numAnalyzing / perpage) === page) { // Processing rows partially fill the page, fill rest of page with past results
+          fetchSize = perpage - (numAnalyzing % perpage);
+        } else { // No processing rows on current page, fill entire page with past results
+          fetchSize = perpage;
+        }
+        // Slice the array of processing rows to display on current page
+        const processingRows = imagesAnalyzing.slice(page * perpage, (page + 1) * perpage);
 
-      if (isMounted) {
+
         if (!maxFeedId || maxFeedId >= 0) {
           // Accumulates with the rows of current page
           let curAnalyses: StudyInstanceWithSeries[] = [];
@@ -166,14 +167,12 @@ const PastAnalysisTable = () => {
               type: AnalysisTypes.Update_are_new_imgs_available,
               payload: { isAvailable: false }
             });
+
+            setLoading(false);
           }
         }
-        if (isMounted) {
-          setLoading(false);
-        }
-      }
-
-    })();
+      })();
+    }
 
     return () => {
       isMounted = false;

--- a/src/components/pastAnalysis/PastAnalysisTable.tsx
+++ b/src/components/pastAnalysis/PastAnalysisTable.tsx
@@ -126,44 +126,53 @@ const PastAnalysisTable = () => {
             const [newAnalyses, newOffset, isAtEndOfFeeds] = await ChrisIntegration.getPastAnalyses(lastOffset, fetchSize, maxFeedId);
 
             // Update latest offset
-            setTableStates(prevTableStates => ({
-              ...prevTableStates,
-              lastOffset: newOffset
-            }));
+            if (isMounted) {
+              setTableStates(prevTableStates => ({
+                ...prevTableStates,
+                lastOffset: newOffset
+              }));
+            }
 
             // If the end of Feeds on Swift has been reached, record the current page as the last page to prevent further navigation by user
             if (isAtEndOfFeeds) {
-              setTableStates(prevTableStates => ({
-                ...prevTableStates,
-                lastPage: page
-              }));
+              if (isMounted) {
+                setTableStates(prevTableStates => ({
+                  ...prevTableStates,
+                  lastPage: page
+                }));
+              }
             }
 
             // Append processing rows to fetched results rows and update storedPages
             curAnalyses = processingRows.concat(newAnalyses);
-            setTableStates(prevTableStates => ({
-              ...prevTableStates,
-              storedPages: [...prevTableStates.storedPages, curAnalyses]
-            }));
+            if (isMounted) {
+              setTableStates(prevTableStates => ({
+                ...prevTableStates,
+                storedPages: [...prevTableStates.storedPages, curAnalyses]
+              }));
+            }
           } else {
             // If page has already been seen, access its contents from storedPages
             curAnalyses = storedPages[page];
           }
+          if (isMounted) {
+            dispatch({
+              type: AnalysisTypes.Update_list,
+              payload: { list: curAnalyses }
+            });
+            updateRows(curAnalyses);
 
-          dispatch({
-            type: AnalysisTypes.Update_list,
-            payload: { list: curAnalyses }
-          });
-          updateRows(curAnalyses);
-
-          dispatch({
-            type: AnalysisTypes.Update_are_new_imgs_available,
-            payload: { isAvailable: false }
-          });
+            dispatch({
+              type: AnalysisTypes.Update_are_new_imgs_available,
+              payload: { isAvailable: false }
+            });
+          }
         }
-        setLoading(false);
+        if (isMounted) {
+          setLoading(false);
+        }
       }
-      
+
     })();
 
     return () => {

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -6,11 +6,25 @@ import PastAnalysisTable from "../../components/pastAnalysis/PastAnalysisTable";
 import Wrapper from "../../containers/Layout/PageWrapper";
 import { AnalysisTypes, NotificationActionTypes, StagingDcmImagesTypes } from "../../context/actions/types";
 import { AppContext } from "../../context/context";
+import { NotificationItem } from "../../context/reducers/notificationReducer";
 import CreateAnalysisService from "../../services/CreateAnalysisService";
 
 type AllProps = RouteComponentProps;
 
 const DashboardPage: React.FC<AllProps> = () => {
+
+  // const useAsync = (asyncFn: any, onSuccess: any) => {
+  //   useEffect(() => {
+  //     let isMounted = true;
+  //     asyncFn(stagingDcmImages, models.xrayModel, models.ctModel).then((data: NotificationItem[]) => {
+  //       if (isMounted) onSuccess(data);
+  //     });
+  //     return () => {
+  //       isMounted = false;
+  //     };
+  //   }, [asyncFn, onSuccess]);
+  // }
+
   const { state: { stagingDcmImages, models }, dispatch } = useContext(AppContext);
 
   useEffect(() => {
@@ -18,22 +32,62 @@ const DashboardPage: React.FC<AllProps> = () => {
     if (stagingDcmImages.length <= 0) return;
 
     // Processing the images
-    CreateAnalysisService.analyzeImages(stagingDcmImages, models.xrayModel, models.ctModel) // Passing selected models to Chris_Integration for image analysis
-      .then((notifications) => {
-        dispatch({
-          type: StagingDcmImagesTypes.UpdateStaging,
-          payload: { imgs: [] }
-        })
-        dispatch({
-          type: AnalysisTypes.Update_are_new_imgs_available,
-          payload: { isAvailable: true }
-        });
-        dispatch({
-          type: NotificationActionTypes.SEND,
-          payload: { notifications }
-        })
+    // CreateAnalysisService.analyzeImages(stagingDcmImages, models.xrayModel, models.ctModel) // Passing selected models to Chris_Integration for image analysis
+    //   .then((notifications) => {
+    //     dispatch({
+    //       type: StagingDcmImagesTypes.UpdateStaging,
+    //       payload: { imgs: [] }
+    //     })
+    //     dispatch({
+    //       type: AnalysisTypes.Update_are_new_imgs_available,
+    //       payload: { isAvailable: true }
+    //     });
+    //     dispatch({
+    //       type: NotificationActionTypes.SEND,
+    //       payload: { notifications }
+    //     })
+    //   });
+
+    // useAsync(CreateAnalysisService.analyzeImages, (notifications: NotificationItem[]) => {
+    //   dispatch({
+    //     type: StagingDcmImagesTypes.UpdateStaging,
+    //     payload: { imgs: [] }
+    //   })
+    //   dispatch({
+    //     type: AnalysisTypes.Update_are_new_imgs_available,
+    //     payload: { isAvailable: true }
+    //   });
+    //   dispatch({
+    //     type: NotificationActionTypes.SEND,
+    //     payload: { notifications }
+    //   })
+    // })
+
+    const updateImages = (notifications: NotificationItem[]) => {
+      dispatch({
+        type: StagingDcmImagesTypes.UpdateStaging,
+        payload: { imgs: [] }
+      })
+      dispatch({
+        type: AnalysisTypes.Update_are_new_imgs_available,
+        payload: { isAvailable: true }
       });
-  }, [dispatch, stagingDcmImages, models.ctModel, models.xrayModel]);
+      dispatch({
+        type: NotificationActionTypes.SEND,
+        payload: { notifications }
+      })
+    }
+
+    let isMounted = true;
+    CreateAnalysisService.analyzeImages(stagingDcmImages, models.xrayModel, models.ctModel).then((data: NotificationItem[]) => {
+        if (isMounted) updateImages(data);
+      });
+      return () => {
+        isMounted = false;
+      };
+
+      
+  }, [dispatch, stagingDcmImages]);
 
   return (
     <Wrapper>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -6,25 +6,11 @@ import PastAnalysisTable from "../../components/pastAnalysis/PastAnalysisTable";
 import Wrapper from "../../containers/Layout/PageWrapper";
 import { AnalysisTypes, NotificationActionTypes, StagingDcmImagesTypes } from "../../context/actions/types";
 import { AppContext } from "../../context/context";
-import { NotificationItem } from "../../context/reducers/notificationReducer";
 import CreateAnalysisService from "../../services/CreateAnalysisService";
 
 type AllProps = RouteComponentProps;
 
 const DashboardPage: React.FC<AllProps> = () => {
-
-  // const useAsync = (asyncFn: any, onSuccess: any) => {
-  //   useEffect(() => {
-  //     let isMounted = true;
-  //     asyncFn(stagingDcmImages, models.xrayModel, models.ctModel).then((data: NotificationItem[]) => {
-  //       if (isMounted) onSuccess(data);
-  //     });
-  //     return () => {
-  //       isMounted = false;
-  //     };
-  //   }, [asyncFn, onSuccess]);
-  // }
-
   const { state: { stagingDcmImages, models }, dispatch } = useContext(AppContext);
 
   useEffect(() => {
@@ -32,62 +18,22 @@ const DashboardPage: React.FC<AllProps> = () => {
     if (stagingDcmImages.length <= 0) return;
 
     // Processing the images
-    // CreateAnalysisService.analyzeImages(stagingDcmImages, models.xrayModel, models.ctModel) // Passing selected models to Chris_Integration for image analysis
-    //   .then((notifications) => {
-    //     dispatch({
-    //       type: StagingDcmImagesTypes.UpdateStaging,
-    //       payload: { imgs: [] }
-    //     })
-    //     dispatch({
-    //       type: AnalysisTypes.Update_are_new_imgs_available,
-    //       payload: { isAvailable: true }
-    //     });
-    //     dispatch({
-    //       type: NotificationActionTypes.SEND,
-    //       payload: { notifications }
-    //     })
-    //   });
-
-    // useAsync(CreateAnalysisService.analyzeImages, (notifications: NotificationItem[]) => {
-    //   dispatch({
-    //     type: StagingDcmImagesTypes.UpdateStaging,
-    //     payload: { imgs: [] }
-    //   })
-    //   dispatch({
-    //     type: AnalysisTypes.Update_are_new_imgs_available,
-    //     payload: { isAvailable: true }
-    //   });
-    //   dispatch({
-    //     type: NotificationActionTypes.SEND,
-    //     payload: { notifications }
-    //   })
-    // })
-
-    const updateImages = (notifications: NotificationItem[]) => {
-      dispatch({
-        type: StagingDcmImagesTypes.UpdateStaging,
-        payload: { imgs: [] }
-      })
-      dispatch({
-        type: AnalysisTypes.Update_are_new_imgs_available,
-        payload: { isAvailable: true }
+    CreateAnalysisService.analyzeImages(stagingDcmImages, models.xrayModel, models.ctModel) // Passing selected models to Chris_Integration for image analysis
+      .then((notifications) => {
+        dispatch({
+          type: StagingDcmImagesTypes.UpdateStaging,
+          payload: { imgs: [] }
+        })
+        dispatch({
+          type: AnalysisTypes.Update_are_new_imgs_available,
+          payload: { isAvailable: true }
+        });
+        dispatch({
+          type: NotificationActionTypes.SEND,
+          payload: { notifications }
+        })
       });
-      dispatch({
-        type: NotificationActionTypes.SEND,
-        payload: { notifications }
-      })
-    }
-
-    let isMounted = true;
-    CreateAnalysisService.analyzeImages(stagingDcmImages, models.xrayModel, models.ctModel).then((data: NotificationItem[]) => {
-        if (isMounted) updateImages(data);
-      });
-      return () => {
-        isMounted = false;
-      };
-
-      
-  }, [dispatch, stagingDcmImages]);
+  }, [dispatch, stagingDcmImages, models.ctModel, models.xrayModel]);
 
   return (
     <Wrapper>


### PR DESCRIPTION
### Problem Statement
Currently, when going to the Dashboard and the PastAnalysisTable is loading, we receive a memory leak error message in the console, if we were to re-route to another part of the app (unmounting Dashboard).
The problem is that PastAnalysisTable still attempts to update the state on the unmounted PastAnalysisTable in Dashboard.

### Implementation
Cancelled async operations and state updates on unmounted component by adding safety checking for the case of Dashboard unmounting PastAnalysisTable. When PastAnalysis is unmounted, we have an indicator for whether it was unmounted, and avoids running state-changing operations in the useEffect upon unmounting.