### PR TITLE
[CNXC-248] Clear selected UIDs on new patient search

### DIFF
--- a/src/context/reducers/createAnalysisReducer.tsx
+++ b/src/context/reducers/createAnalysisReducer.tsx
@@ -48,7 +48,9 @@ export const createAnalysisReducer = (
     case CreateAnalysisTypes.Update_patient_ID:
       return {
         ...state,
-        patientID: action.payload.patientID
+        patientID: action.payload.patientID,
+        selectedStudyUIDs: {},
+        currSelectedStudyUID: ""
       }
     case CreateAnalysisTypes.Add_selected_studies_UID:
       return {


### PR DESCRIPTION
### Problem Statement
DICOM files remain selected after re-searching for the same patient.

### Steps to Reproduce
1. Search for a patient "A"
2. Select a DICOM file
3. Search for another patient "B"
4. Search for patient "A". The DICOM file that was selected will remain selected

### Implementation
The Create Analysis Reducer was modified to clear the `selectedStudyUIDs` and `currSelectedStudyUID` when the `patientID` is updated.