### PR TITLE
[CNXC-292] Remove Privacy Level field Drop-down

### DIFF
--- a/src/assets/scss/components/PatientLookup.scss
+++ b/src/assets/scss/components/PatientLookup.scss
@@ -15,7 +15,7 @@
 }
 
 .PatientLookupWrapper {
-  padding-bottom: 0em;
+  padding-bottom: 0;
 }
 
 .noImagesFound {
@@ -27,4 +27,5 @@
 
 .form-display {
   display: inline-flex;
+  width: 100%;
 }

--- a/src/assets/scss/components/PatientLookup.scss
+++ b/src/assets/scss/components/PatientLookup.scss
@@ -3,7 +3,7 @@
   flex-direction: row;
   margin: 1rem;
   .InputRowField {
-    width: 25%;
+    width: 30em;
     padding-right: 1rem;
     display: flex;
     flex-direction: column;
@@ -11,14 +11,11 @@
     label {
       font-weight: bold;
     }
-    #toggle-Privacy-Level {
-      width: 1000px;
-    }
   }
 }
 
 .PatientLookupWrapper {
-  padding-bottom: 0px;
+  padding-bottom: 0em;
 }
 
 .noImagesFound {

--- a/src/components/PatientLookup.tsx
+++ b/src/components/PatientLookup.tsx
@@ -1,22 +1,12 @@
-import {
-  Button, Dropdown,
-  DropdownItem, DropdownToggle,
-  TextInput
-} from '@patternfly/react-core';
+import { Button,TextInput } from "@patternfly/react-core";
 import React, { useContext, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { CreateAnalysisTypes, DicomImagesTypes } from "../context/actions/types";
 import { AppContext } from "../context/context";
 import RightArrowButton from "../pages/CreateAnalysisPage/RightArrowButton";
-import chris_integration from '../services/chris_integration';
-import pacs_integration from '../services/pacs_integration';
+import chris_integration from "../services/chris_integration";
+import pacs_integration from "../services/pacs_integration";
 import CreateAnalysisService, { StudyInstance } from "../services/CreateAnalysisService";
-
-enum PrivacyLevel {
-  ANONYMIZE_ALL_DATA = "Anonymize all data",
-  ANONYMIZE_X_DATA = "X"
-}
-
 interface PatientLookupProps {
   isOnDashboard: boolean
 }
@@ -25,21 +15,8 @@ const PatientLookup: React.FC<PatientLookupProps> = ({ isOnDashboard }) => {
   const { state: { createAnalysis: { patientID } } } = useContext(AppContext);
 
   const { dispatch } = useContext(AppContext);
-  const [privacyLevel, setPrivacyLevel] = useState(PrivacyLevel.ANONYMIZE_ALL_DATA)
   const [patientIDInput, setPatientIDInput] = useState<string>((patientID && !isOnDashboard) ? patientID : "");
   const history = useHistory();
-
-  const [isDropDownOpen, setDropDownOpen] = React.useState(false);
-
-  const onSelect = () => {
-    setDropDownOpen(!isDropDownOpen);
-    onFocus();
-  }
-
-  const onFocus = () => {
-    const element = document.getElementById('toggle-Privacy-Level');
-    if (element) element.focus();
-  };
 
   const newLookup = async (event?: React.FormEvent) => {
     event?.preventDefault();
@@ -81,15 +58,6 @@ const PatientLookup: React.FC<PatientLookupProps> = ({ isOnDashboard }) => {
     }
   }
 
-  const dropdownItems = [
-    <DropdownItem key="Anonymize all data" onClick={() => setPrivacyLevel(PrivacyLevel.ANONYMIZE_ALL_DATA)}>
-      {PrivacyLevel.ANONYMIZE_ALL_DATA}
-    </DropdownItem>,
-    <DropdownItem key="Anonymize x data" onClick={() => setPrivacyLevel(PrivacyLevel.ANONYMIZE_X_DATA)}>
-      {PrivacyLevel.ANONYMIZE_X_DATA}
-    </DropdownItem>,
-  ];
-
   const submitButton = isOnDashboard ? (
     <RightArrowButton type="submit">Continue</RightArrowButton>
   ) : (
@@ -105,21 +73,6 @@ const PatientLookup: React.FC<PatientLookupProps> = ({ isOnDashboard }) => {
           <div className="InputRowField">
             <label>Patient MRN</label>
             <TextInput value={patientIDInput} type="text" onChange={setPatientIDInput} aria-label="MRN Search Field" />
-          </div>
-          <div className="InputRowField">
-            <label>Privacy Level</label>
-            <Dropdown
-              onSelect={onSelect}
-              toggle={
-                <DropdownToggle id="toggle-Privacy-Level" onToggle={setDropDownOpen}>
-                  <div className="dropdownContent">
-                    {privacyLevel}
-                  </div>
-                </DropdownToggle>
-              }
-              isOpen={isDropDownOpen}
-              dropdownItems={dropdownItems}
-            />
           </div>
           <div className="InputRowField">
             {submitButton}


### PR DESCRIPTION
### Problem Statement
The Privacy Level select field used for anonymization of data needs to be removed from the dashboard page.
Originally, the purpose of that setting was to anonymize personal data during public demos. 

### Implementation
Removed the Privacy Level drop-down from the PatientLookup component, (along with any of its dependent code), then adjusted styling of the patient look-up bar