### PR TITLE
[CNXC 182] Update plugin status options

### DIFF
--- a/src/services/chris_integration.tsx
+++ b/src/services/chris_integration.tsx
@@ -31,9 +31,10 @@ interface PACSFile {
 
 enum PluginPollStatus {
   CREATED = "created",
+  WAITING = "waiting",
   SCHEDULED = "scheduled",
-  WAITING = "waitingForPrevious",
   STARTED = "started",
+  REGISTERING_FILES = "registeringFiles",
   SUCCESS = "finishedSuccessfully",
   ERROR = "finishedWithError",
   CANCELLED = "cancelled"


### PR DESCRIPTION
Remove ` WAITING_FOR_PREVIOUS = "waitingForPrevious",` from `PluginPollStatus` enum.