### PR TITLE
[CNXC-302] Add routing feature into COVID-Net Title in Header

### DIFF
--- a/src/assets/scss/layout/_layout.scss
+++ b/src/assets/scss/layout/_layout.scss
@@ -24,7 +24,7 @@
     }
   }
 
-  a:hover {
+  a {
     text-decoration: none;
   }
 }

--- a/src/assets/scss/layout/_layout.scss
+++ b/src/assets/scss/layout/_layout.scss
@@ -23,6 +23,10 @@
       display: none !important;
     }
   }
+
+  a:hover {
+    text-decoration: none;
+  }
 }
 
 h1,

--- a/src/assets/scss/layout/layout.scss
+++ b/src/assets/scss/layout/layout.scss
@@ -51,16 +51,6 @@
   min-width: 190px;
 }
 
-.title {
-  background: none;
-	color: inherit;
-	border: none;
-	padding: 0;
-	font: inherit;
-	cursor: pointer;
-	outline: inherit;
-}
-
 .pf-c-page__header-brand {
   min-height: 70px;
   min-width: 190px;

--- a/src/assets/scss/layout/layout.scss
+++ b/src/assets/scss/layout/layout.scss
@@ -51,6 +51,16 @@
   min-width: 190px;
 }
 
+.title {
+  background: none;
+	color: inherit;
+	border: none;
+	padding: 0;
+	font: inherit;
+	cursor: pointer;
+	outline: inherit;
+}
+
 .pf-c-page__header-brand {
   min-height: 70px;
   min-width: 190px;

--- a/src/components/CreateAnalysis/CreateAnalysis.tsx
+++ b/src/components/CreateAnalysis/CreateAnalysis.tsx
@@ -27,6 +27,7 @@ const CreateAnalysis: React.FC = () => {
   //     };
   //   });
   // }
+  
 
   // const submitFile = () => {
   //   openLocalFilePicker().then(async (files: LocalFile[]) => {

--- a/src/containers/Layout/Header.tsx
+++ b/src/containers/Layout/Header.tsx
@@ -83,7 +83,7 @@ const Header: React.FC<HeaderProps> = ({ onNotificationBadgeClick }) => {
     headerTools={pageToolbar}
     logo={<>
       <img onClick={() => history.push("/")} src={logo} className="logo" alt="DarwinAI Logo" />
-      <button onClick={() => history.push("/")} className="title"><span className="logo-text">COVID-Net</span></button>
+      <span onClick={() => history.push("/")} className="logo-text">COVID-Net</span>
     </>}
     topNav={<PageNav />}
   />;

--- a/src/containers/Layout/Header.tsx
+++ b/src/containers/Layout/Header.tsx
@@ -83,7 +83,7 @@ const Header: React.FC<HeaderProps> = ({ onNotificationBadgeClick }) => {
     headerTools={pageToolbar}
     logo={<>
       <img onClick={() => history.push("/")} src={logo} className="logo" alt="DarwinAI Logo" />
-      <button onClick={() => history.push("/")} className="title"><span className="logo-text">COVID-Net</span></button>
+      <Link to="/" className="logo-text">COVID-Net</Link>
     </>}
     topNav={<PageNav />}
   />;

--- a/src/containers/Layout/Header.tsx
+++ b/src/containers/Layout/Header.tsx
@@ -81,10 +81,10 @@ const Header: React.FC<HeaderProps> = ({ onNotificationBadgeClick }) => {
     className="header"
     aria-label="Page Header"
     headerTools={pageToolbar}
-    logo={<React.Fragment>
+    logo={<>
       <img onClick={() => history.push("/")} src={logo} className="logo" alt="DarwinAI Logo" />
-      <span className="logo-text">COVID-Net</span>
-    </React.Fragment>}
+      <button onClick={() => history.push("/")} className="title"><span className="logo-text">COVID-Net</span></button>
+    </>}
     topNav={<PageNav />}
   />;
 }

--- a/src/containers/Layout/Header.tsx
+++ b/src/containers/Layout/Header.tsx
@@ -83,7 +83,7 @@ const Header: React.FC<HeaderProps> = ({ onNotificationBadgeClick }) => {
     headerTools={pageToolbar}
     logo={<>
       <img onClick={() => history.push("/")} src={logo} className="logo" alt="DarwinAI Logo" />
-      <span onClick={() => history.push("/")} className="logo-text">COVID-Net</span>
+      <button onClick={() => history.push("/")} className="title"><span className="logo-text">COVID-Net</span></button>
     </>}
     topNav={<PageNav />}
   />;


### PR DESCRIPTION
### Problem Statement
The header title appears as a click-able feature for routing, but does not re-route the user back anywhere

### Implementation
Added routing feature into COVID-Net title in header, changed <span> to <button> tag, and calling on the history hook to link back to the Dashboard