### PR TITLE
[CNXC-282] CI to Docker Hub

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check Out epo
+      - name: Check Out repo
         uses: actions/checkout@v2
         
       - name: Set release tag

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -1,0 +1,51 @@
+name: CI to Docker Hub
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Build and push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Out epo
+        uses: actions/checkout@v2
+        
+      - name: Set release tag
+        run: |
+          echo "RELEASE_TAG=${GITHUB_REF}#refs/tags/" >> $GITHUB_ENV
+    
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+            
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPO }}:${{ github.event.release.tag_name || env.RELEASE_TAG }}, ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPO }}:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -43,7 +43,7 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPO }}:${{ github.event.release.tag_name || env.RELEASE_TAG }}, ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPO }}:latest
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/covidnet-ui:${{ github.event.release.tag_name || env.RELEASE_TAG }}, ${{ secrets.DOCKER_HUB_USERNAME }}/covidnet-ui:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 


### PR DESCRIPTION
**CI to Docker Hub**
Added Github workflow for building and pushing a Docker image to Docker Hub whenever a new `release` is published.