### PR TITLE
[CNXC-294] Use StudyDate and SeriesDescription on CreateAnalysisPage

### DIFF
--- a/src/components/CreateAnalysis/CreateAnalysisDetail.tsx
+++ b/src/components/CreateAnalysis/CreateAnalysisDetail.tsx
@@ -25,7 +25,7 @@ const CreateAnalysisDetail: React.FC<CreateAnalysisDetailProps> = ({ setIsExpand
   const [patientBirthdate, setPatientBirthdate] = useState("");
   const [patientSex, setPatientSex] = useState("");
 
-  useEffect(() => { // here
+  useEffect(() => {
     const image: DcmImage = dcmImages?.allDcmImages[0];
     if (image) {
       setPatientName(image.PatientName);
@@ -34,7 +34,7 @@ const CreateAnalysisDetail: React.FC<CreateAnalysisDetailProps> = ({ setIsExpand
     }
   }, [dcmImages]);
 
-  const studyInstances: StudyInstance[] = CreateAnalysisService.extractStudyInstances(dcmImages?.filteredDcmImages); // here
+  const studyInstances: StudyInstance[] = CreateAnalysisService.extractStudyInstances(dcmImages?.filteredDcmImages);
   const numOfSelectedImages: number = CreateAnalysisService.findTotalImages(createAnalysis.selectedStudyUIDs);
 
   const setModelType = (modality: string) => {

--- a/src/components/CreateAnalysis/CreateAnalysisDetail.tsx
+++ b/src/components/CreateAnalysis/CreateAnalysisDetail.tsx
@@ -25,7 +25,7 @@ const CreateAnalysisDetail: React.FC<CreateAnalysisDetailProps> = ({ setIsExpand
   const [patientBirthdate, setPatientBirthdate] = useState("");
   const [patientSex, setPatientSex] = useState("");
 
-  useEffect(() => {
+  useEffect(() => { // here
     const image: DcmImage = dcmImages?.allDcmImages[0];
     if (image) {
       setPatientName(image.PatientName);
@@ -34,7 +34,7 @@ const CreateAnalysisDetail: React.FC<CreateAnalysisDetailProps> = ({ setIsExpand
     }
   }, [dcmImages]);
 
-  const studyInstances: StudyInstance[] = CreateAnalysisService.extractStudyInstances(dcmImages?.filteredDcmImages);
+  const studyInstances: StudyInstance[] = CreateAnalysisService.extractStudyInstances(dcmImages?.filteredDcmImages); // here
   const numOfSelectedImages: number = CreateAnalysisService.findTotalImages(createAnalysis.selectedStudyUIDs);
 
   const setModelType = (modality: string) => {

--- a/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
+++ b/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
@@ -35,7 +35,7 @@ const CreateAnalysisWrapper = () => {
           console.error('Unable to initiate PACS retrieve');
           return;
         }
-      })
+      });
 
       // Update fname property of each image to be the filepath in Swift filesystem
       try {

--- a/src/components/CreateAnalysis/SelectedStudyDetail.tsx
+++ b/src/components/CreateAnalysis/SelectedStudyDetail.tsx
@@ -64,7 +64,7 @@ const SelectedStudyDetail = () => {
               const isSelected: boolean = CreateAnalysisService.isImgSelected(selectedStudyUIDs, img);
               return (
                 <div className="half_width margin-top-bottom" key={i}>
-                  <label className={`container ${isSelected ? 'blueText' : null}`}>{img.ProtocolName}
+                  <label className={`container ${isSelected ? 'blueText' : null}`}>{img.SeriesDescription || img.SeriesDescription}
                     <input type="checkbox" checked={isSelected} onChange={() => addImgToAnalysis(isSelected, img)} />
                     <span className="checkmark"></span>
                   </label>

--- a/src/components/CreateAnalysis/SelectedStudyDetail.tsx
+++ b/src/components/CreateAnalysis/SelectedStudyDetail.tsx
@@ -64,7 +64,7 @@ const SelectedStudyDetail = () => {
               const isSelected: boolean = CreateAnalysisService.isImgSelected(selectedStudyUIDs, img);
               return (
                 <div className="half_width margin-top-bottom" key={i}>
-                  <label className={`container ${isSelected ? 'blueText' : null}`}>{img.SeriesDescription || img.SeriesDescription}
+                  <label className={`container ${isSelected ? 'blueText' : null}`}>{img.SeriesDescription}
                     <input type="checkbox" checked={isSelected} onChange={() => addImgToAnalysis(isSelected, img)} />
                     <span className="checkmark"></span>
                   </label>

--- a/src/components/CreateAnalysis/SelectedStudyDetail.tsx
+++ b/src/components/CreateAnalysis/SelectedStudyDetail.tsx
@@ -64,7 +64,7 @@ const SelectedStudyDetail = () => {
               const isSelected: boolean = CreateAnalysisService.isImgSelected(selectedStudyUIDs, img);
               return (
                 <div className="half_width margin-top-bottom" key={i}>
-                  <label className={`container ${isSelected ? 'blueText' : null}`}>{img.fname.split('/')[3]}
+                  <label className={`container ${isSelected ? 'blueText' : null}`}>{img.ProtocolName}
                     <input type="checkbox" checked={isSelected} onChange={() => addImgToAnalysis(isSelected, img)} />
                     <span className="checkmark"></span>
                   </label>

--- a/src/components/CreateAnalysis/SelectionStudy.tsx
+++ b/src/components/CreateAnalysis/SelectionStudy.tsx
@@ -9,7 +9,6 @@ const SelectionStudy: React.FC<StudyInstance> = ({
   studyDescription,
   modality,
   studyDate,
-  protocolName,
   setModelType
 }) => {
   const { state: { createAnalysis: { selectedStudyUIDs, currSelectedStudyUID } }, dispatch } = useContext(AppContext);

--- a/src/components/CreateAnalysis/SelectionStudy.tsx
+++ b/src/components/CreateAnalysis/SelectionStudy.tsx
@@ -8,7 +8,8 @@ const SelectionStudy: React.FC<StudyInstance> = ({
   studyInstanceUID,
   studyDescription,
   modality,
-  createdDate,
+  studyDate,
+  protocolName,
   setModelType
 }) => {
   const { state: { createAnalysis: { selectedStudyUIDs, currSelectedStudyUID } }, dispatch } = useContext(AppContext);
@@ -31,8 +32,10 @@ const SelectionStudy: React.FC<StudyInstance> = ({
     });
   }
 
+  console.log(studyDate)
+
   const isSelected: boolean = !!imagesSelectedDict && Object.keys(imagesSelectedDict).length > 0;
-  
+
   return (
     <div
       className={`SelectionStudy ${isSelected ? 'selected' : ''}`}
@@ -42,7 +45,7 @@ const SelectionStudy: React.FC<StudyInstance> = ({
         {isSelected ?
           (<Badge>{Object.keys(imagesSelectedDict).length}</Badge>) : null}
         &nbsp;{studyDescription}</h1>
-      <p className="greyText"><span className="outtline-box">{modality}</span> {createdDate} </p>
+      <p className="greyText"><span className="outtline-box">{modality}</span> {studyDate}</p>
     </div>
   )
 }

--- a/src/components/CreateAnalysis/SelectionStudy.tsx
+++ b/src/components/CreateAnalysis/SelectionStudy.tsx
@@ -31,8 +31,6 @@ const SelectionStudy: React.FC<StudyInstance> = ({
     });
   }
 
-  console.log(studyDate)
-
   const isSelected: boolean = !!imagesSelectedDict && Object.keys(imagesSelectedDict).length > 0;
 
   return (

--- a/src/context/reducers/dicomImagesReducer.tsx
+++ b/src/context/reducers/dicomImagesReducer.tsx
@@ -1,21 +1,21 @@
 import { ActionMap, DicomImagesTypes } from "../actions/types";
 
 export interface DcmImage {
-  id: number,
-  creation_date: string,
-  fname: string,
-  PatientID: string
-  PatientName: string,
-  PatientBirthDate: string,
-  PatientAge: number,
-  PatientSex: string,
-  StudyInstanceUID: string,
-  StudyDescription: string,
-  SeriesInstanceUID: string,
-  SeriesDescription: string,
-  StudyDate: string,
-  Modality: string,
-  pacs_identifier: string
+  id: number;
+  creation_date: string;
+  fname: string;
+  PatientID: string;
+  PatientName: string;
+  PatientBirthDate: string;
+  PatientAge: number;
+  PatientSex: string;
+  StudyInstanceUID: string;
+  StudyDescription: string;
+  SeriesInstanceUID: string;
+  SeriesDescription: string;
+  StudyDate: string;
+  Modality: string;
+  pacs_identifier: string;
 }
 
 export interface PACSResponseProperty {

--- a/src/context/reducers/dicomImagesReducer.tsx
+++ b/src/context/reducers/dicomImagesReducer.tsx
@@ -13,6 +13,8 @@ export interface DcmImage {
   StudyDescription: string,
   SeriesInstanceUID: string,
   SeriesDescription: string,
+  StudyDate: string,
+  ProtocolName: string,
   Modality: string,
   pacs_identifier: string
 }
@@ -49,6 +51,7 @@ export interface PACSBaseResponse {
   StudyInstanceUID: PACSResponseProperty;
   SeriesInstanceUID: PACSResponseProperty;
   InstanceNumber: PACSResponseProperty;
+  ProtocolName: PACSResponseProperty;
   NumberOfSeriesRelatedInstances: PACSResponseProperty;
   PerformedStationAETitle: PACSResponseProperty;
 }

--- a/src/context/reducers/dicomImagesReducer.tsx
+++ b/src/context/reducers/dicomImagesReducer.tsx
@@ -14,7 +14,7 @@ export interface DcmImage {
   SeriesInstanceUID: string,
   SeriesDescription: string,
   StudyDate: string,
-  ProtocolName: string,
+  ProtocolName?: string,
   Modality: string,
   pacs_identifier: string
 }

--- a/src/context/reducers/dicomImagesReducer.tsx
+++ b/src/context/reducers/dicomImagesReducer.tsx
@@ -14,7 +14,6 @@ export interface DcmImage {
   SeriesInstanceUID: string,
   SeriesDescription: string,
   StudyDate: string,
-  ProtocolName?: string,
   Modality: string,
   pacs_identifier: string
 }
@@ -51,7 +50,6 @@ export interface PACSBaseResponse {
   StudyInstanceUID: PACSResponseProperty;
   SeriesInstanceUID: PACSResponseProperty;
   InstanceNumber: PACSResponseProperty;
-  ProtocolName: PACSResponseProperty;
   NumberOfSeriesRelatedInstances: PACSResponseProperty;
   PerformedStationAETitle: PACSResponseProperty;
 }

--- a/src/services/CreateAnalysisService.tsx
+++ b/src/services/CreateAnalysisService.tsx
@@ -6,11 +6,11 @@ import NotificationService from "./notificationService";
 import { formatDate } from "../shared/utils";
 
 export interface StudyInstance {
-  studyInstanceUID: string,
-  studyDescription: string,
-  modality: string,
-  studyDate: string,
-  setModelType?: (modality: string) => void
+  studyInstanceUID: string;
+  studyDescription: string;
+  modality: string;
+  studyDate: string;
+  setModelType?: (modality: string) => void;
 }
 
 export interface AnalyzedImageResult {

--- a/src/services/CreateAnalysisService.tsx
+++ b/src/services/CreateAnalysisService.tsx
@@ -10,7 +10,6 @@ export interface StudyInstance {
   studyDescription: string,
   modality: string,
   studyDate: string,
-  protocolName: string,
   setModelType?: (modality: string) => void
 }
 
@@ -32,8 +31,7 @@ class CreateAnalysisService {
           studyInstanceUID: img.StudyInstanceUID,
           studyDescription: img.StudyDescription,
           modality: img.Modality,
-          studyDate: formatDate(img.StudyDate),
-          protocolName: img.ProtocolName
+          studyDate: formatDate(img.StudyDate)
         })
         seenUID[img.StudyInstanceUID] = true;
       }

--- a/src/services/CreateAnalysisService.tsx
+++ b/src/services/CreateAnalysisService.tsx
@@ -6,11 +6,12 @@ import NotificationService from "./notificationService";
 import { formatDate } from "../shared/utils";
 
 export interface StudyInstance {
-  studyInstanceUID: string;
-  studyDescription: string;
-  modality: string;
-  createdDate: string;
-  setModelType?: (modality: string) => void;
+  studyInstanceUID: string,
+  studyDescription: string,
+  modality: string,
+  studyDate: string,
+  protocolName: string,
+  setModelType?: (modality: string) => void
 }
 
 export interface AnalyzedImageResult {
@@ -25,12 +26,14 @@ class CreateAnalysisService {
     const seenUID: { [uid: string]: boolean } = {}
     dcmImages.forEach((img: DcmImage) => {
       // met a new uid
+      console.log(img.StudyDate)
       if (!seenUID[img.StudyInstanceUID]) {
         studyInstances.push({
           studyInstanceUID: img.StudyInstanceUID,
           studyDescription: img.StudyDescription,
           modality: img.Modality,
-          createdDate: formatDate(img.creation_date)
+          studyDate: formatDate(img.StudyDate),
+          protocolName: img.ProtocolName
         })
         seenUID[img.StudyInstanceUID] = true;
       }

--- a/src/services/CreateAnalysisService.tsx
+++ b/src/services/CreateAnalysisService.tsx
@@ -25,7 +25,6 @@ class CreateAnalysisService {
     const seenUID: { [uid: string]: boolean } = {}
     dcmImages.forEach((img: DcmImage) => {
       // met a new uid
-      console.log(img.StudyDate)
       if (!seenUID[img.StudyInstanceUID]) {
         studyInstances.push({
           studyInstanceUID: img.StudyInstanceUID,

--- a/src/services/chris_integration.tsx
+++ b/src/services/chris_integration.tsx
@@ -397,8 +397,6 @@ class ChrisIntegration {
       limit: 1000
     })
     const patientImages: DcmImage[] = res.getItems().map((img: PACSFile) => img.data);
-    //console.log(patientImages[0].StudyDate);
-    console.log(res.getItems());
     return patientImages;
   }
 

--- a/src/services/chris_integration.tsx
+++ b/src/services/chris_integration.tsx
@@ -397,6 +397,8 @@ class ChrisIntegration {
       limit: 1000
     })
     const patientImages: DcmImage[] = res.getItems().map((img: PACSFile) => img.data);
+    //console.log(patientImages[0].StudyDate);
+    console.log(res.getItems());
     return patientImages;
   }
 
@@ -410,7 +412,7 @@ class ChrisIntegration {
     const plugin = pluginInstance.getItems()[0]
     const pluginInstanceFiles = await plugin.getFiles({
       limit: 25,
-      offset: 0,
+      offset: 0
     });
     return pluginInstanceFiles.getItems();
   }

--- a/src/services/pacs_integration.tsx
+++ b/src/services/pacs_integration.tsx
@@ -57,7 +57,6 @@ class PACSIntegration {
                         SeriesInstanceUID: series.SeriesInstanceUID.value,
                         SeriesDescription: series.SeriesDescription.value,
                         StudyDate: series.StudyDate.value,
-                        ProtocolName: series.ProtocolName?.value,
                         Modality: series.Modality.value,
                         pacs_identifier: 'covidnet'
                 }))

--- a/src/services/pacs_integration.tsx
+++ b/src/services/pacs_integration.tsx
@@ -57,7 +57,7 @@ class PACSIntegration {
                         SeriesInstanceUID: series.SeriesInstanceUID.value,
                         SeriesDescription: series.SeriesDescription.value,
                         StudyDate: series.StudyDate.value,
-                        ProtocolName: series.ProtocolName.value,
+                        ProtocolName: series.ProtocolName?.value,
                         Modality: series.Modality.value,
                         pacs_identifier: 'covidnet'
                 }))

--- a/src/services/pacs_integration.tsx
+++ b/src/services/pacs_integration.tsx
@@ -56,6 +56,8 @@ class PACSIntegration {
                         StudyDescription: series.StudyDescription.value,
                         SeriesInstanceUID: series.SeriesInstanceUID.value,
                         SeriesDescription: series.SeriesDescription.value,
+                        StudyDate: series.StudyDate.value,
+                        ProtocolName: series.ProtocolName.value,
                         Modality: series.Modality.value,
                         pacs_identifier: 'covidnet'
                 }))


### PR DESCRIPTION
## Problem Statement
Currently, the date being displayed under each study is not the study date and the Series are labelled using their DICOM file names. The UI should be reading the StudyDate and SeriesDescription properties from the DICOM metadata and display these instead.

## Implementation
With the new updates made to CUBE, `getPACSFiles` now returns a DICOM metadata object that includes the StudyDate, so this is used to display the appropriate date under each study. The SeriesDescription is now being used instead of the fname to label each series.