### PR TITLE
[CNXC-290] Update Colours of Prediction Circles

### DIFF
--- a/src/components/PredictionCircle.tsx
+++ b/src/components/PredictionCircle.tsx
@@ -21,7 +21,7 @@ const PredictionCircle: React.FC<circleProps> = ({largeCircle, predictionNumber,
     thresholds: [{value: 0}, {value: 90}]
   }
 
-  if (!largeCircle) { // check boolean condition here
+  if (!largeCircle) {
     predictionCircleAttributes.height = 150;
     predictionCircleAttributes.width = 150;
     divSize = "80px";

--- a/src/components/PredictionCircle.tsx
+++ b/src/components/PredictionCircle.tsx
@@ -28,7 +28,6 @@ const PredictionCircle: React.FC<circleProps> = ({largeCircle, predictionNumber,
   }
 
   if (isNormal) {
-    console.log("cheese");
     predictionCircleAttributes.thresholds = [];
   }
 

--- a/src/components/PredictionCircle.tsx
+++ b/src/components/PredictionCircle.tsx
@@ -18,7 +18,7 @@ const PredictionCircle: React.FC<circleProps> = ({largeCircle, predictionNumber,
     width: 120,
     padding: 0,
     title: `${predictionNumber}%`,
-    thresholds: [{value: 60}, {value: 90}]
+    thresholds: [{value: 0}, {value: 90}]
   }
 
   if (!largeCircle) { // check boolean condition here

--- a/src/components/PredictionCircle.tsx
+++ b/src/components/PredictionCircle.tsx
@@ -4,29 +4,39 @@ import React from "react";
 interface circleProps {
   largeCircle: boolean;
   predictionNumber: number;
+  isNormal: boolean;
 }
 
-const PredictionCircle = (props: circleProps) => {
-  const { largeCircle, predictionNumber } = props
-  let size = 120
-  let divSize = '100px'
-  if (!largeCircle) {
-    size = 150
-    divSize = "80px"
+const PredictionCircle: React.FC<circleProps> = ({largeCircle, predictionNumber, isNormal}) => {
+  let divSize = '100px';
+
+  let predictionCircleAttributes = {
+    ariaDesc: "Prediction Result of Analysis",
+    constrainToVisibleArea: true,
+    data: { x: 'Prediction', y: predictionNumber },
+    height: 120,
+    width: 120,
+    padding: 0,
+    title: `${predictionNumber}%`,
+    thresholds: [{value: 60}, {value: 90}]
   }
+
+  if (!largeCircle) { // check boolean condition here
+    predictionCircleAttributes.height = 150;
+    predictionCircleAttributes.width = 150;
+    divSize = "80px";
+  }
+
+  if (isNormal) {
+    console.log("cheese");
+    predictionCircleAttributes.thresholds = [];
+  }
+
   return (
     <div style={{ height: divSize, width: divSize }}>
-      <ChartDonutUtilization
-        ariaDesc="Storage capacity"
-        constrainToVisibleArea={true}
-        data={{ x: 'Prediction', y: predictionNumber }}
-        height={size}
-        width={size}
-        padding={0}
-        title={`${predictionNumber}%`}
-        thresholds={[{ value: 60 }, { value: 90 }]}
-      />
+      <ChartDonutUtilization {...predictionCircleAttributes} />
     </div>
   )
 }
+
 export default PredictionCircle

--- a/src/components/dicmViewer/dicomViewerBottomBox.tsx
+++ b/src/components/dicmViewer/dicomViewerBottomBox.tsx
@@ -38,12 +38,12 @@ const DicomViewerBottomBox = () => {
       return;
     }
 
-     // Dynamically generate the titles to display for the classifications
-      series.classifications.forEach((value: number, key: string) => {
-        bottomDisplay.push(<p key={key}>{key}: <span className="blueText">{value}</span></p>);
-      });
+    // Dynamically generate the titles to display for the classifications
+    series.classifications.forEach((value: number, key: string) => {
+      bottomDisplay.push(<p key={key}>{key}: <span className="blueText">{value}</span></p>);
+    });
 
-      return bottomDisplay;
+    return bottomDisplay;
   }
 
   const generateDisplayCircles = (series?: ISeries) => {
@@ -51,19 +51,22 @@ const DicomViewerBottomBox = () => {
 
     if (!series) {
       return;
-    } 
-    
-     // Dynamically display the prediction classes/values in the dicomviewerbottombox
-      series.classifications.forEach((value: number, key: string) => {
-        displayCircles.push(<div className="PredictionArea" key={key}>
-        <PredictionCircle largeCircle={isLargestNumber(value, series.classifications)}
-          predictionNumber={value}/>
+    }
+
+    // Dynamically display the prediction classes/values in the dicomviewerbottombox
+    series.classifications.forEach((value: number, key: string) => {
+      displayCircles.push(<div className="PredictionArea" key={key}>
+        <PredictionCircle
+          largeCircle={isLargestNumber(value, series.classifications)}
+          predictionNumber={value}
+          isNormal={key === 'Normal'}
+          />
         <div className="topMargin">{key}</div>
       </div>)
-      });
+    });
 
-      return displayCircles;
-    }
+    return displayCircles;
+  }
 
   return (
     <div id="ViewerbottomBox"
@@ -72,7 +75,7 @@ const DicomViewerBottomBox = () => {
         <div className='predictionValues moveUp'>
 
           {generateBottomDisplay(imageDetail)}
-        
+
         </div>
         <span className="pointer" onClick={toggle}>{!isBottomHided ? 'hide ' : 'expand '}</span>	&nbsp;
         <span className="pointer" onClick={toggle}>
@@ -99,7 +102,7 @@ const DicomViewerBottomBox = () => {
           <div className="predictions padding-l-2rem">
             <span className='logo-text'>COVID-Net</span>
             <div className="flex_row">
-            
+
               {generateDisplayCircles(imageDetail)}
 
               <div className="padding-l-2rem">

--- a/src/components/pastAnalysis/seriesTable.tsx
+++ b/src/components/pastAnalysis/seriesTable.tsx
@@ -65,7 +65,9 @@ const SeriesTable: React.FC<SeriesTableProps> = ({ studyInstance, classification
         analysisCells.push({
           title: (<PredictionCircle key={key}
             largeCircle={isLargestNumber(value, analysis.classifications)}
-            predictionNumber={value} />)
+            predictionNumber={value} 
+            isNormal={key === 'Normal'}
+            />)
         });
       });
     } else if (classifications?.length) { // If this Series' analysis was unsuccessful, but the list of classes is known, display 'N/A' for each classification result


### PR DESCRIPTION
### Problem Statement
As a user, I would like to see red color reserved for COVID-19 results in order to make it more distinct from Normal and Pneumonia results. Additionally, I would like disease classifications to always be yellow/red to make it easier to read

### Implementation
Updated PredictionCircle to now check whether it is meant for a `Normal` analysis result, and also default to yellow/red for any other case (a disease prediction)