### PR TITLE
[CNXC-302] Fix header logo wrapper

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -22,7 +22,6 @@
 @import './components/CreateAnalysisDetail.scss';
 @import './components/ConfirmAnalysis.scss';
 @import './components/SelectionStudy.scss';
-@import './components/ImageSelectionBox.scss';
 @import './components/SelectedStudyDetail.scss';
 @import './components/DicomImageViewer.scss';
 @import './components/seriesTable.scss';

--- a/src/containers/Layout/Header.tsx
+++ b/src/containers/Layout/Header.tsx
@@ -85,6 +85,7 @@ const Header: React.FC<HeaderProps> = ({ onNotificationBadgeClick }) => {
       <img onClick={() => history.push("/")} src={logo} className="logo" alt="DarwinAI Logo" />
       <Link to="/" className="logo-text">COVID-Net</Link>
     </>}
+    logoComponent={"div"}
     topNav={<PageNav />}
   />;
 }


### PR DESCRIPTION
### Problem Statement
The header logo contents, which contain an `<a>`, were being wrapped in an `<a>` by default. Anchors cannot be nested in an anchor.

### Implementation
Use the logoComponent prop to change the logo wrapper to be a `<div`.