### PR TITLE
[CNXC-343] Display Series Description in dropdown for each study in PastAnalyses 

### DIFF
--- a/src/components/CreateAnalysis/ImageSelectionBox.tsx
+++ b/src/components/CreateAnalysis/ImageSelectionBox.tsx
@@ -33,8 +33,8 @@ const ImageSelectionBox: React.FC<ImageSelectionBoxProps> = ({ img }) => {
           <img src={image_placeholder} alt="selected" width={60} height={60} />
           <div className="margin_left">
             <p className="color_grey">{StudyDescription}</p>
-            <p className="color_grey">Filename{fname.split('/')[3]}</p>
-            <p className="color_grey">{formatDate(creation_date)}</p>
+            <p className="color_grey">{"Filename: " + fname.split('/')[3]}</p>
+            <p className="color_grey">{"Date: " + formatDate(creation_date)}</p>
           </div>
         </div>
       </div>

--- a/src/components/pastAnalysis/seriesTable.tsx
+++ b/src/components/pastAnalysis/seriesTable.tsx
@@ -47,7 +47,7 @@ const SeriesTable: React.FC<SeriesTableProps> = ({ data, dcmImage, isProcessing 
 
   let titles = [
     { title: (<span className='classificationText'><br />Preview</span>) },
-    { title: (<span className='classificationText'><br />Image</span>) }
+    { title: (<span className='classificationText'><br />Description</span>) }
   ];
 
   if (values.classifications.length) {
@@ -68,7 +68,7 @@ const SeriesTable: React.FC<SeriesTableProps> = ({ data, dcmImage, isProcessing 
     const isAnalysisValid = !!analysis.classifications.size;
     let analysisCells: any = [
       { title: (analysis.imageUrl ? <div><img src={analysis.imageUrl} className="thumbnail" alt="Analysis Scan Thumbnail" /></div> : <div><PreviewNotAvailable/></div>) },
-      { title: (<div><b>{analysis.imageName.split('/').pop()}</b></div>) }
+      { title: (<div><b>{dcmImage.SeriesDescription}</b></div>) }
     ];
 
     if (isAnalysisValid) { // If this Series' analysis was successful, read in its analysis results


### PR DESCRIPTION
Showing image file names for studies in PastAnalyses isn't desirable behaviour. Instead, we want to have Series Descriptions for each image (shown below for example)
![image](https://user-images.githubusercontent.com/53355975/118191745-1420bc00-b413-11eb-9dd1-2652dad29742.png)
Replacing it in the same location
![image](https://user-images.githubusercontent.com/53355975/118191831-3a465c00-b413-11eb-8e7a-0a66d931f2cd.png)

