### PR TITLE
[CNXC-254] Implement loading UI for patient search

### DIFF
--- a/src/components/PatientLookup.tsx
+++ b/src/components/PatientLookup.tsx
@@ -8,10 +8,11 @@ import chris_integration from "../services/chris_integration";
 import pacs_integration from "../services/pacs_integration";
 import CreateAnalysisService, { StudyInstance } from "../services/CreateAnalysisService";
 interface PatientLookupProps {
-  setHasSearched: (newValue: boolean) => void
+  setHasSearched: (newValue: boolean) => void,
+  setIsSearching: (newValue: boolean) => void
 }
 
-const PatientLookup: React.FC<PatientLookupProps> = ({ setHasSearched }) => {
+const PatientLookup: React.FC<PatientLookupProps> = ({ setHasSearched, setIsSearching }) => {
   const { state: { createAnalysis: { patientID } }, dispatch } = useContext(AppContext);
 
   const [patientIDInput, setPatientIDInput] = useState<string>(patientID ? patientID : "");
@@ -29,6 +30,9 @@ const PatientLookup: React.FC<PatientLookupProps> = ({ setHasSearched }) => {
     });
 
     try {
+
+      setIsSearching(true);
+
       const dcmImages = process.env.REACT_APP_CHRIS_UI_DICOM_SOURCE === 'pacs' ?
         await pacs_integration.queryPatientFiles(patientIDInput) :
         await chris_integration.fetchPacFiles(patientIDInput);
@@ -39,6 +43,8 @@ const PatientLookup: React.FC<PatientLookupProps> = ({ setHasSearched }) => {
           images: dcmImages
         }
       });
+
+      setIsSearching(false);
 
       // Select first study instance by default
       const studyInstances: StudyInstance[] = CreateAnalysisService.extractStudyInstances(dcmImages);
@@ -51,6 +57,7 @@ const PatientLookup: React.FC<PatientLookupProps> = ({ setHasSearched }) => {
         });
       }
     } catch (err) {
+      setIsSearching(false);
       console.error(err);
     }
   }

--- a/src/pages/CreateAnalysisPage/CreateAnalysisPage.tsx
+++ b/src/pages/CreateAnalysisPage/CreateAnalysisPage.tsx
@@ -1,4 +1,4 @@
-import { PageSection, PageSectionVariants } from "@patternfly/react-core";
+import { PageSection, PageSectionVariants, Spinner } from "@patternfly/react-core";
 import React, { useState } from "react";
 import CreateAnalysisWrapper from "../../components/CreateAnalysis/CreateAnalysisWrapper";
 import PatientLookup from "../../components/PatientLookup";
@@ -9,23 +9,34 @@ import Error from "../../shared/error";
 const CreateAnalysisPage = () => {
   const { state: { dcmImages, createAnalysis: { patientID } } } = React.useContext(AppContext);
   const [hasSearched, setHasSearched] = useState(patientID && patientID !== "");
+  const [isSearching, setIsSearching] = useState(false);
+  let pageSectionContent;
+
+  if(isSearching){
+    pageSectionContent = (
+      <div className="loading">
+        <Spinner size="xl" /> &nbsp; Searching
+      </div>
+    );
+  } else if(dcmImages.allDcmImages.length > 0) {
+    pageSectionContent = (
+      <CreateAnalysisWrapper></CreateAnalysisWrapper>
+    );
+  }else {
+    pageSectionContent = (
+    <Error>{ hasSearched ? "No studies found for MRN #" + patientID : "Search for a patient by entering their MRN above" } </Error>
+  );
+  }
 
   return (
     <Wrapper>
       <PageSection className="page-body">
         <PageSection className="section-area" variant={PageSectionVariants.light}>
-          <PatientLookup setHasSearched={setHasSearched}></PatientLookup>
+          <PatientLookup setHasSearched={setHasSearched} setIsSearching={setIsSearching}></PatientLookup>
         </PageSection>
-          {
-            dcmImages.allDcmImages.length > 0 ?
-              <PageSection variant={PageSectionVariants.light}>
-                <CreateAnalysisWrapper></CreateAnalysisWrapper>
-              </PageSection>
-              :
-              <PageSection className="page-section-no-results" variant={PageSectionVariants.light}>
-                <Error>{ hasSearched ? "No studies found for MRN #" + patientID : "Search for a patient by entering their MRN above" } </Error>
-              </PageSection>
-          }
+          <PageSection variant={PageSectionVariants.light}>
+            {pageSectionContent}
+            </PageSection>
         </PageSection>
     </Wrapper>
   )


### PR DESCRIPTION
While wait times for fetching from a local Swift or PACS are negligible, in a production environment, there will be significant delay. So, while we are in the process of searching, we will visually indicate that fetching is occurring with a spinner.
![image](https://user-images.githubusercontent.com/53355975/118337219-51537f80-b4e1-11eb-81af-0f0edf093e0b.png)
