### PR TITLE
[CNXC-347] Reroute if series information is unavailable

### DIFF
--- a/src/components/dicmViewer/dicomViewerBottomBox.tsx
+++ b/src/components/dicmViewer/dicomViewerBottomBox.tsx
@@ -1,13 +1,16 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { ImageViewerTypes } from "../../context/actions/types";
 import { AppContext } from "../../context/context";
 import { ISeries } from "../../context/reducers/analyseReducer";
 import { isLargestNumber } from "../pastAnalysis/seriesTable";
 import PredictionCircle from "../PredictionCircle";
 import { formatGender } from "../../shared/utils";
+import { useHistory } from 'react-router-dom';
 
 const DicomViewerBottomBox = () => {
   const { state: { imgViewer: { isBottomHided }, prevAnalyses: { selectedImage } }, dispatch } = useContext(AppContext);
+
+  const history = useHistory();
 
   const toggle = () => {
     dispatch({
@@ -29,6 +32,12 @@ const DicomViewerBottomBox = () => {
 
   //2018 01 05 2y 6m
   const { dcmImage, series } = selectedImage;
+
+  useEffect(() => {
+    if(!series){
+      history.push('/');
+    }
+  }, [history, series]);
 
   const generateBottomDisplay = (series?: ISeries) => {
     let bottomDisplay: any = [];


### PR DESCRIPTION
The only ways to properly access the DICOM viewer page should be from ‘View Image’ from the Dashboard analyses rows, or from the notification panel.

Going there directly, or reloading the page once already there will result in a blank DICOM viewer page, and the app should re-direct the user to the Dashboard again. 

We get a blank DICOM viewer page only if the information isn't acquired through our desired means (by pressing View from one of the rows of the PastAnalysis table), so under these cases, we are good to redirect back to the Dashboard.