### PR TITLE
[CNXC-364] Fix post-pdf-generation PastAnalyses table row showing analysis failed

### DIFF
--- a/src/services/chris_integration.tsx
+++ b/src/services/chris_integration.tsx
@@ -444,10 +444,11 @@ class ChrisIntegration {
       feed_id: feedId,
       plugin_name: BASE_COVIDNET_MODEL_PLUGIN_NAME
     });
-    return model ? pluginData.getItems()?.filter(item => {
-      const pluginName = item.data.plugin_name;
-      return Object.values(PluginModels.XrayModels).includes(pluginName) || Object.values(PluginModels.CTModels).includes(pluginName);
-    })[0] : pluginData.getItems()?.[0];
+
+    const modelSet: Set<String> = new Set([...Object.values(PluginModels.XrayModels), ...Object.values(PluginModels.CTModels)]);
+
+    // Done under the assumption that only one model plugin is being used, otherwise will need to be more specific in parameters
+    return model ? pluginData.getItems()?.filter(item => modelSet.has(item.data.plugin_name))[0] : pluginData.getItems()?.[0];
   }
 
   /**


### PR DESCRIPTION
PastAnalyses table was retrieving most recent plugin instance/resource's files instead of the specific model's files, so the right information was being failed to be displayed. This was fixed by looking specifically for the model's plugin name in the list of plugin instances and using that plugin instance. 