### PR TITLE
[CNXC-362] Classify covidnet ui feeds in their names

### DIFF
--- a/src/services/chris_integration.tsx
+++ b/src/services/chris_integration.tsx
@@ -349,7 +349,10 @@ class ChrisIntegration {
 
       curOffset += limit;
       
-      const feedArray: Feed[] = feeds?.getItems();
+        const feedArray: Feed[] = feeds?.getItems().filter((feed: Feed) => {
+		    const separatedString: string[] = feed.data.name.split('-');
+		    return separatedString.length && separatedString[0] === 'covidnet_ui';
+        });
 
       // If the number of Feeds in the response was less than fetchLimit, it means that the end of Feeds in the DB has been reached
       isAtEndOfFeeds = feedArray?.length < limit;

--- a/src/services/chris_integration.tsx
+++ b/src/services/chris_integration.tsx
@@ -176,7 +176,7 @@ class ChrisIntegration {
 
       // PL-DIRCOPY
       const dircopyPlugin = (await client.getPlugins({ "name_exact": PluginModels.Plugins.FS_PLUGIN })).getItems()[0];
-      const data: DirCreateData = { "dir": img.fname, title: img.PatientID };
+      const data: DirCreateData = { "dir": img.fname, title: `covidnet_ui-${img.PatientID}` };
       const dircopyPluginInstance: PluginInstance = await client.createPluginInstance(dircopyPlugin.data.id, data);
       const feed = await dircopyPluginInstance.getFeed();
       const note = await feed?.getNote();


### PR DESCRIPTION
In a production setting with many different UIs, there's a chance that not all feeds will belong to the covidnet UI. In our dev environment, we currently don't do anything to distinguish them.

Before
![beforeName](https://user-images.githubusercontent.com/53355975/121096341-06ffae80-c7c0-11eb-94ea-915edef08d8f.png)

After
![afterName](https://user-images.githubusercontent.com/53355975/121096345-09fa9f00-c7c0-11eb-9daa-898887da29f0.png)

Chris UI
![chris_ui-Names](https://user-images.githubusercontent.com/53355975/121096358-1121ad00-c7c0-11eb-8e54-bacb2b5f736e.png)

