### PR TITLE
[CNXC-376] Add PNG file support for chris files

### DIFF
--- a/src/services/chris_integration.tsx
+++ b/src/services/chris_integration.tsx
@@ -466,7 +466,11 @@ class ChrisIntegration {
     const prediction = await this.fetchJsonFiles(predictionFileId);
     const severityFileId =  files.filter((file: any) => file.data.fname.replace(/^.*[\\\/]/, '') === "severity.json")?.[0]?.data?.id;
     const severity = await this.fetchJsonFiles(severityFileId);
-    const imageFileId =  files.filter((file: any) => file.data.fname.match(/\.[0-9a-z]+$/i)[0] === ".jpg")?.[0]?.data?.id;
+    const imageFileId =  files.filter(
+        (file: any) =>
+            file.data.fname.match(/\.[0-9a-z]+$/i)[0] === ".jpg"
+            || file.data.fname.match(/\.[0-9a-z]+$/i)[0] === ".png" 
+        )?.[0]?.data?.id;
     
     let imageUrl: string = "";
     if (imageFileId) {


### PR DESCRIPTION
One of the FNNDSC workflows requires the usage of png files, and they’d encounter issues accessing the png files because of the hardcoded assumptions that we use a jpg (from med2img). 

Before
![beforePngSupport](https://user-images.githubusercontent.com/53355975/121543940-4f44e980-c9d7-11eb-9c23-1309ae212848.png)

After
![afterPngSupport](https://user-images.githubusercontent.com/53355975/121543951-53710700-c9d7-11eb-8430-56a7fff80352.png)

ChrisUI
![chrisPngSupport](https://user-images.githubusercontent.com/53355975/121543999-5d930580-c9d7-11eb-8e11-7d55dd3cd7e4.png)
