### PR TITLE
[CNXC-365] Remove link from COVID-NET text in navbar

### DIFF
--- a/src/containers/Layout/Header.tsx
+++ b/src/containers/Layout/Header.tsx
@@ -78,7 +78,7 @@ const Header: React.FC<HeaderProps> = ({ onNotificationBadgeClick }) => {
     headerTools={pageToolbar}
     logo={<>
       <img onClick={() => history.push("/")} src={logo} className="logo" alt="DarwinAI Logo" />
-      <Link to="/" className="logo-text">COVID-Net</Link>
+      <p className="logo-text">COVID-Net</p>
     </>}
     logoComponent={"div"}
     topNav={<PageNav />}


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/53355975/122102843-e2b95880-cde3-11eb-9f4a-ed5bfd9d3bf5.png)
After
![image](https://user-images.githubusercontent.com/53355975/122102870-ea78fd00-cde3-11eb-98aa-967cfb998fa6.png)