### PR TITLE
[CNXC-406] Add patient name as column to PastAnalysisTable

### DIFF
--- a/src/components/pastAnalysis/PastAnalysisTable.tsx
+++ b/src/components/pastAnalysis/PastAnalysisTable.tsx
@@ -124,7 +124,7 @@ const PastAnalysisTable: React.FC = () => {
       title: "Status",
       cellFormatters: [expandable]
     },
-    "Study", "Study Date", "# Images", "Patient MRN", "Patient DOB", "Analysis Created"
+    "Study", "Study Date", "# Images", "Patient Name", "Patient MRN", "Patient DOB", "Analysis Created"
   ]
   const [rows, setRows] = useState<(tableRowsChild | tableRowsParent)[]>([])
 
@@ -263,6 +263,7 @@ const PastAnalysisTable: React.FC = () => {
         analysis.dcmImage.StudyDescription,
         analysis.dcmImage.StudyDate,
         numImagesOutput,
+        analysis.dcmImage.PatientName,
         analysis.dcmImage.PatientID,
         `${analysis.dcmImage.PatientBirthDate} (${calculatePatientAge(analysis.dcmImage.PatientBirthDate)}y)`,
         analysisCreated,


### PR DESCRIPTION
Problem:
The past analysis results only lists MRN and not patient name, making the location task a little more difficult as it involves scanning long MRN numbers rather than looking for a recognizable patient name.

Screenshot of change:
![image](https://user-images.githubusercontent.com/53355975/129086295-01b82caa-1c30-46c0-a73a-86f49f75a65f.png)
