### PR TITLE
[CNXC-405] improve MRN search in PastAnalyses table

### DIFF
--- a/src/components/pastAnalysis/PastAnalysisTable.tsx
+++ b/src/components/pastAnalysis/PastAnalysisTable.tsx
@@ -15,6 +15,7 @@ import { RESULT_POLL_INTERVAL } from "../../app.config";
 import { debounce } from "lodash";
 import { NotificationItem, NotificationItemVariant } from "../../context/reducers/notificationReducer";
 import moment from "moment";
+import Error from "../../shared/error";
 
 interface tableRowsParent {
   isOpen: boolean,
@@ -412,7 +413,7 @@ const PastAnalysisTable: React.FC = () => {
         <div className="loading">
           <Spinner size="xl" /> &nbsp; Loading
         </div>
-      ) : (
+      ) : ( rows.length > 0 ? (
         <Table aria-label="Collapsible table" id="pastAnalysisTable"
           onCollapse={onCollapse} rows={rows} cells={columns}
           rowWrapper={customRowWrapper}
@@ -420,9 +421,10 @@ const PastAnalysisTable: React.FC = () => {
           <TableHeader />
           <TableBody />
         </Table>
-      )
-      }
-    </div>
+        ) : <Error>{!!tableState.filter ? `No analyses found with filter ${tableState.filter}` 
+        : "Create an analysis by clicking the Create Analysis button"}</Error>
+      )}
+    </div> 
   );
 }
 

--- a/src/components/pastAnalysis/PastAnalysisTable.tsx
+++ b/src/components/pastAnalysis/PastAnalysisTable.tsx
@@ -421,7 +421,7 @@ const PastAnalysisTable: React.FC = () => {
           <TableHeader />
           <TableBody />
         </Table>
-        ) : <Error>{!!tableState.filter ? `No analyses found with filter ${tableState.filter}` 
+        ) : <Error>{!!tableState.filter ? `No analyses found with filter "${tableState.filter}"` 
         : "Create an analysis by clicking the Create Analysis button"}</Error>
       )}
     </div> 

--- a/src/services/chris_integration.tsx
+++ b/src/services/chris_integration.tsx
@@ -354,7 +354,7 @@ class ChrisIntegration {
       const feeds: FeedList = await client.getFeeds({
         limit: limit,
         offset: curOffset,
-        name: !!filter ? this.getFeedName(filter): "", // get feed name based on filter, which should be the patientID/MRN
+        name_startswith: !!filter ? this.getFeedName(filter): "", // get feed name based on filter, which should be the patientID/MRN
         max_id
       });
 


### PR DESCRIPTION
Problem:
The MRN search box for past analyses was pretty unforgiving and a number of copy/paste errors, extra spaces, added dashes, etc. caused a lot of confusion and delay in finding past analyses.

Solution:
We requested for partial feed name filter matching functionality from the ChRIS team and added it as a new parameter. We also added some additional error components to be more informative to users.

Note: partial feed name filter matching works after this [commit](https://github.com/FNNDSC/ChRIS_ultron_backEnd/pull/337/commits/466a2b654d177b341859eefc8fb8207e498e8058) in the ChRIS backend.

Message when there have been no analyses/predictions made.
![No_Analyses](https://user-images.githubusercontent.com/53355975/129087063-5477d959-cd5e-4689-a7df-fe3d632b3876.png)

Regular dashboard
![image](https://user-images.githubusercontent.com/53355975/129087464-bfa533df-abaf-44f0-a3f0-874aea4249fd.png)

Search for invalid prediction
![image](https://user-images.githubusercontent.com/53355975/129087407-4dcbc8cc-684a-443e-a468-77e61b5ca8f7.png)

Partial name matching and filtering
![image](https://user-images.githubusercontent.com/53355975/129087606-2c6e553b-b692-48f9-93c1-b92513ffe4c6.png)


