### PR TITLE
[CNXC-404] Make Analyze button fixed to page and add border

### DIFF
--- a/src/assets/scss/components/CreateAnalysisDetail.scss
+++ b/src/assets/scss/components/CreateAnalysisDetail.scss
@@ -84,6 +84,9 @@ $description-top-padding: 0.3rem;
       justify-content: center;
       align-items: center;
       line-height: 1.5;
+      position: fixed;
+      z-index: 1;
+      border: 1px solid;
       
       .numberCircle {
         border-radius: 50%;

--- a/src/assets/scss/components/CreateAnalysisDetail.scss
+++ b/src/assets/scss/components/CreateAnalysisDetail.scss
@@ -86,7 +86,10 @@ $description-top-padding: 0.3rem;
       line-height: 1.5;
       position: fixed;
       z-index: 1;
-      border: 1px solid;
+      box-shadow: 0 1px 1px rgba(0,0,0,0.15), 
+                  0 2px 2px rgba(0,0,0,0.15), 
+                  0 4px 4px rgba(0,0,0,0.15), 
+                  0 8px 8px rgba(0,0,0,0.15);
       
       .numberCircle {
         border-radius: 50%;


### PR DESCRIPTION
Problem:
On lower-resolution screens, “create analysis” button in upper right corner of screen is not visible and can take a lot of scrolling to reach

Solution: 
Make Analyze button and its surrounding components in CreateAnalysis page fixed with respect to the page

![image](https://user-images.githubusercontent.com/53355975/129087868-06aa67d8-feee-4774-bb22-efbc4691963a.png)

![image](https://user-images.githubusercontent.com/53355975/129087907-dfd22518-80dd-437b-917f-16b4f5ae53e3.png)

![image](https://user-images.githubusercontent.com/53355975/129087924-fd88456a-4c34-4f58-bfa2-094709eceab5.png)
