### PR TITLE
[CNXC-403] Selected study clarity

### DIFF
--- a/src/components/CreateAnalysis/SelectedStudyDetail.tsx
+++ b/src/components/CreateAnalysis/SelectedStudyDetail.tsx
@@ -25,7 +25,7 @@ const SelectedStudyDetail = () => {
   }
 
   if (images.length > 0) {
-    const { StudyDescription, PatientBirthDate, Modality, PatientName } = images[0];
+    const { StudyDescription, PatientBirthDate, Modality, StudyDate } = images[0];
     return (
       <div className="detail-select">
         <div className="flex_row">
@@ -40,6 +40,10 @@ const SelectedStudyDetail = () => {
               <div className="half_width">
                 <h2 className="bold med-size">Performed Station</h2>
                 <p className="color_grey">Station1234</p>
+              </div>
+              <div className="half_width">
+                <h2 className="bold med-size">Study Date</h2>
+                <p className="color_grey">{StudyDate}</p>
               </div>
             </div>
           </div>

--- a/src/components/CreateAnalysis/SelectionStudy.tsx
+++ b/src/components/CreateAnalysis/SelectionStudy.tsx
@@ -35,7 +35,7 @@ const SelectionStudy: React.FC<StudyInstance> = ({
 
   return (
     <div
-      className={`SelectionStudy ${isSelected ? 'selected' : 'notSelected'}`}
+      className={`SelectionStudy ${currSelectedStudyUID === studyInstanceUID ? 'selected' : 'notSelected'}`}
       onClick={selectThisStudy}
     >
       <h1 id="studyDescription" className={`${currSelectedStudyUID === studyInstanceUID ? 'blueText' : ''}`}>


### PR DESCRIPTION
Problem:

It was unclear for some testers that as they selected studies in the left panel of the create new analysis screen, that the right side was updating accordingly. Likely this is exacerbated due to repetitive, filler metadata on the test data. However, a stronger visual link between the left panel and right panel would definitely improve the usability of this screen.

Solution:

- Highlight study row (like it currently is when you select a series from that study) whenever you select that study instead of the status quo
- Add date at the top of series selection panel

![image](https://user-images.githubusercontent.com/53355975/129088357-e6ddac2e-9f98-40f4-9037-d9c691981eaa.png)