### PR TITLE
[CNXC-402] Add sorting by study date then study desc to study instance extraction

### DIFF
--- a/src/services/CreateAnalysisService.tsx
+++ b/src/services/CreateAnalysisService.tsx
@@ -37,7 +37,22 @@ class CreateAnalysisService {
       }
     })
 
-    return studyInstances;
+    // Sort by study date in descending order first, 
+    // then by study description in descending order
+    const sortedStudyInstances: StudyInstance[] = studyInstances.sort(
+      (a: StudyInstance, b: StudyInstance): number => {
+        const aDate = new Date(a.studyDate);
+        const bDate = new Date(b.studyDate);
+        if (aDate > bDate){
+          return -1;
+        }else if(aDate < bDate){
+          return 1;
+        }else {
+          return a.studyDescription <= b.studyDescription ? 1 : -1;
+        }
+      });
+
+    return sortedStudyInstances;
   }
 
   static returnAllImagesInOneStudy(dcmImages: DcmImage[], studyUID: string): DcmImage[] {


### PR DESCRIPTION
Problem:

When looking up MRN on create new analysis screen, the list of studies on the left is not always in date order.

Looks like studies are sorted lexicographically in descending order first, then by date

![image](https://user-images.githubusercontent.com/53355975/129090634-d0d798e9-50a1-4604-9499-2f088148b9c7.png)

Suggestion:

Always list studies in reverse chronological order when displaying MRN results here: most recent study on top down to least recent studies.

![image](https://user-images.githubusercontent.com/53355975/129090860-1147deb3-e4f5-4486-bf80-80e8962e8cbd.png)

