### PR TITLE
[CNXC-409] Removal of image state retention for create analysis page 

### DIFF
--- a/src/components/PatientLookup.tsx
+++ b/src/components/PatientLookup.tsx
@@ -13,9 +13,9 @@ interface PatientLookupProps {
 }
 
 const PatientLookup: React.FC<PatientLookupProps> = ({ setHasSearched, setIsSearching }) => {
-  const { state: { createAnalysis: { patientID } }, dispatch } = useContext(AppContext);
+  const { dispatch } = useContext(AppContext);
 
-  const [patientIDInput, setPatientIDInput] = useState<string>(patientID ? patientID : "");
+  const [patientIDInput, setPatientIDInput] = useState<string>("");
 
   const newLookup = async (event?: React.FormEvent) => {
     event?.preventDefault();

--- a/src/pages/CreateAnalysisPage/CreateAnalysisPage.tsx
+++ b/src/pages/CreateAnalysisPage/CreateAnalysisPage.tsx
@@ -1,15 +1,27 @@
 import { PageSection, PageSectionVariants, Spinner } from "@patternfly/react-core";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import CreateAnalysisWrapper from "../../components/CreateAnalysis/CreateAnalysisWrapper";
 import PatientLookup from "../../components/PatientLookup";
 import Wrapper from "../../containers/Layout/PageWrapper";
+import { DicomImagesTypes } from "../../context/actions/types";
 import { AppContext } from "../../context/context";
+import { initialIDcmImagesState } from "../../context/reducers/dicomImagesReducer";
 import Error from "../../shared/error";
 
 const CreateAnalysisPage = () => {
-  const { state: { dcmImages, createAnalysis: { patientID } } } = React.useContext(AppContext);
-  const [hasSearched, setHasSearched] = useState(patientID && patientID !== "");
+  const { state: { dcmImages, createAnalysis: { patientID } }, dispatch } = React.useContext(AppContext);
+  const [hasSearched, setHasSearched] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
+
+  useEffect( () => {
+    dispatch({
+      type: DicomImagesTypes.Update_all_images,
+      payload: {
+        images: initialIDcmImagesState
+      }
+    });
+  }, []);
+  
   let pageSectionContent;
 
   if(isSearching){

--- a/src/pages/CreateAnalysisPage/CreateAnalysisPage.tsx
+++ b/src/pages/CreateAnalysisPage/CreateAnalysisPage.tsx
@@ -14,12 +14,15 @@ const CreateAnalysisPage = () => {
   const [isSearching, setIsSearching] = useState(false);
 
   useEffect( () => {
-    dispatch({
-      type: DicomImagesTypes.Update_all_images,
-      payload: {
-        images: initialIDcmImagesState
-      }
-    });
+    // Clean up function for when user leaves the CreateAnalysis page
+    return () => {
+      dispatch({
+        type: DicomImagesTypes.Update_all_images,
+        payload: {
+          images: initialIDcmImagesState
+        }
+      });
+    }
   }, []);
   
   let pageSectionContent;


### PR DESCRIPTION
Create analysis page retained current patientId and images even when switching to other pages and logging out. It was determined that this was generally undesirable behaviour, so we made it so that state is reset whenever the user leaves the page.