### PR TITLE
[CNXC-401] page ordering fork without code-specific terminology change

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The app supports the user to choose from multiple models. For testing purposes o
 5. In the app.config.tsx file, add the correct entries into the Xray and CT Models section, where the key can be anything (which will be displayed to user on front-end), and the value is the plug-in name from 3a and 3b
 6. Now, the front-end will present the user the added models to select from (in the drop-down menu), when creating an analysis
     7a. The mocked pl-covidnet and pl-ct-covidnet models should be displayed on the drop-down and able to be selected by the user
-    7b. After creating the analysis, the results will be shown on the dashboard, where there will now be 2 or 4 classifications displayed for the scan now
+    7b. After creating the analysis, the results will be shown on the Past Predictions dashboard, where there will now be 2 or 4 classifications displayed for the scan now
 ```
 ### PACS Integration
 

--- a/src/RouterWrapper.tsx
+++ b/src/RouterWrapper.tsx
@@ -28,7 +28,7 @@ const RouterWrapper: React.FC = ({ children }) => {
           payload: user
         });
         
-        // If on Login page and already authenticated, go to Dashboard
+        // If on Login page and already authenticated, go to Generate Prediction/Create Analysis page
         if (location.pathname === "/login") {
           history.push('/');
         }

--- a/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
+++ b/src/components/CreateAnalysis/CreateAnalysisWrapper.tsx
@@ -58,11 +58,12 @@ const CreateAnalysisWrapper = () => {
       payload: { notifications }
     });
     
-    history.push("/");
+    history.push("/pastPredictions");
 
     dispatch({
       type: CreateAnalysisTypes.Clear_selected_studies_UID
     });
+    
   }
 
   const panelContent = (

--- a/src/components/dicmViewer/dicomViewerHeader.tsx
+++ b/src/components/dicmViewer/dicomViewerHeader.tsx
@@ -59,7 +59,7 @@ const DicomViewerHeader = () => {
     <div id="ViewerHeaderBox" className="flex_row dicomViewerHeader">
       <div className="headerlogo padding_left_right_2rem">
         <span className='logo-text'>COVID-Net</span>
-        <a onClick={(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {history.push('/'); e.preventDefault();}} href="/#"> <i className="fas fa-angle-left"></i> Back to Dashboard</a>
+        <a onClick={(e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {history.push('/pastPredictions'); e.preventDefault();}} href="/#"> <i className="fas fa-angle-left"></i> Back to Past Predictions</a>
       </div>
       <div className='padding_left_right_2rem'>
         {/* Tools

--- a/src/containers/Layout/PageNav.tsx
+++ b/src/containers/Layout/PageNav.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Link, useLocation } from 'react-router-dom';
 
 const navMap = [
-  { 'label': 'Create Analysis', 'path': '/' },
+  { 'label': 'Generate Prediction', 'path': '/' },
   { 'label': 'Past Predictions', 'path': '/pastPredictions' }
 ];
 

--- a/src/containers/Layout/PageNav.tsx
+++ b/src/containers/Layout/PageNav.tsx
@@ -3,8 +3,8 @@ import React from "react";
 import { Link, useLocation } from 'react-router-dom';
 
 const navMap = [
-  { 'label': 'Dashboard', 'path': '/' },
-  { 'label': 'Create Analysis', 'path': '/createAnalysis' }
+  { 'label': 'Create Analysis', 'path': '/' },
+  { 'label': 'Past Predictions', 'path': '/pastPredictions' }
 ];
 
 const PageNav = () => {

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -15,12 +15,12 @@ const DashboardPage: React.FC<AllProps> = () => {
     <Wrapper>
       <PageSection className="page-body">
         <PageSection className="section-area" variant={PageSectionVariants.light}>
-          <Alert isInline variant="warning" title="Patient lookup designated to Create Analysis page">
-            <p>To look up a patient and create a new analysis, please go to the Create Analysis page.</p>
+          <Alert isInline variant="warning" title="Patient lookup designated to Generate Prediction page">
+            <p>To look up a patient and generate a new prediction, please go to the Generate Prediction page.</p>
           </Alert>
           <Button variant="link" isLarge className="pf-u-pl-0" 
           onClick={() => history.push('/')}> 
-          Create Analysis <ArrowRightIcon/>
+          Generate Prediction <ArrowRightIcon/>
           </Button>
         </PageSection>
         <PageSection className="flex-column" variant={PageSectionVariants.light}>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -19,7 +19,7 @@ const DashboardPage: React.FC<AllProps> = () => {
             <p>To look up a patient and create a new analysis, please go to the Create Analysis page.</p>
           </Alert>
           <Button variant="link" isLarge className="pf-u-pl-0" 
-          onClick={() => history.push('/createAnalysis')}> 
+          onClick={() => history.push('/')}> 
           Create Analysis <ArrowRightIcon/>
           </Button>
         </PageSection>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -16,8 +16,8 @@ const Routes: React.FunctionComponent = () => (
   <React.Fragment>
     <Switch>
       <Route exact path="/login" component={LogInPage} />
-      <PrivateRoute exact component={Dashboard} path="/" />
-      <PrivateRoute exact component={CreateAnalysisPage} path="/createAnalysis" />
+      <PrivateRoute exact component={CreateAnalysisPage} path="/" />
+      <PrivateRoute exact component={Dashboard} path="/pastPredictions" />
       <PrivateRoute exact component={ViewImagePage} path="/viewImage" />
       <Route component={NotFound} />
     </Switch>


### PR DESCRIPTION
Similar to #96, but with terminology changes only within comments, documentation, and the UI itself. This also includes fixes from making ordering switches in the first place. Therefore, for the most part, it does not impact functionality of other components.